### PR TITLE
Folders and Files tinting & filtering customizations

### DIFF
--- a/app/src/main/java/com/nextcloud/client/media/NextcloudExoPlayer.kt
+++ b/app/src/main/java/com/nextcloud/client/media/NextcloudExoPlayer.kt
@@ -42,7 +42,9 @@ object NextcloudExoPlayer {
             .setMediaSourceFactory(mediaSourceFactory)
             .setAudioAttributes(AudioAttributes.DEFAULT, true)
             .setHandleAudioBecomingNoisy(true)
-            .setSeekForwardIncrementMs(FIVE_SECONDS_IN_MILLIS)
+            // NMC-3192 Fix
+            .setSeekBackIncrementMs(2 * FIVE_SECONDS_IN_MILLIS)
+            .setSeekForwardIncrementMs(2 * FIVE_SECONDS_IN_MILLIS)
             .build()
     }
 }

--- a/app/src/main/java/com/nextcloud/utils/ShortcutUtil.kt
+++ b/app/src/main/java/com/nextcloud/utils/ShortcutUtil.kt
@@ -15,6 +15,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
+import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.createBitmap
@@ -93,9 +94,12 @@ class ShortcutUtil @Inject constructor(private val mContext: Context) {
 
             file.isFolder -> {
                 val isAutoUploadFolder = SyncedFolderObserver.isAutoUploadFolder(file, user)
-                val isDarkModeActive = syncedFolderProvider.preferences.isDarkModeEnabled
                 val overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder)
-                val drawable = MimeTypeUtil.getFolderIcon(isDarkModeActive, overlayIconId, mContext, viewThemeUtils)
+                // NMC Customization: No overlay icon will be used. Directly using folder icons
+                val drawable = ContextCompat.getDrawable(mContext, overlayIconId) ?: MimeTypeUtil.getDefaultFolderIcon(
+                    mContext,
+                    viewThemeUtils
+                )
                 IconCompat.createWithBitmap(drawable.toBitmap())
             }
 

--- a/app/src/main/java/com/nmc/android/utils/KeyboardUtils.java
+++ b/app/src/main/java/com/nmc/android/utils/KeyboardUtils.java
@@ -1,0 +1,21 @@
+package com.nmc.android.utils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+
+public class KeyboardUtils {
+
+    public static void showSoftKeyboard(Context context, View view) {
+        view.requestFocus();
+        InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT);
+    }
+
+    public static void hideKeyboardFrom(Context context, View view) {
+        view.clearFocus();
+        InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+    }
+}

--- a/app/src/main/java/com/owncloud/android/media/MediaControlView.kt
+++ b/app/src/main/java/com/owncloud/android/media/MediaControlView.kt
@@ -351,5 +351,7 @@ class MediaControlView(context: Context, attrs: AttributeSet?) :
     companion object {
         private val TAG = MediaControlView::class.java.getSimpleName()
         private const val SHOW_PROGRESS = 1
+        // NMC-3192 Fix
+        private const val FIVE_SECONDS_IN_MILLIS = 5000
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -44,6 +44,8 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import androidx.core.content.ContextCompat;
+
 public abstract class EditorWebView extends ExternalSiteWebView {
     public static final int REQUEST_LOCAL_FILE = 101;
     public ValueCallback<Uri[]> uploadMessage;
@@ -255,8 +257,8 @@ public abstract class EditorWebView extends ExternalSiteWebView {
             boolean isAutoUploadFolder = SyncedFolderObserver.INSTANCE.isAutoUploadFolder(file, user);
 
             Integer overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder);
-            LayerDrawable drawable = MimeTypeUtil.getFolderIcon(preferences.isDarkModeEnabled(), overlayIconId, this, viewThemeUtils);
-            binding.thumbnail.setImageDrawable(drawable);
+            // NMC Customization: No overlay icon will be used. Directly using folder icons
+            binding.thumbnail.setImageDrawable(ContextCompat.getDrawable(this, overlayIconId));
         } else {
             if ((MimeTypeUtil.isImage(file) || MimeTypeUtil.isVideo(file)) && file.getRemoteId() != null) {
                 // Thumbnail in cache?

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -86,6 +86,7 @@ import com.nextcloud.utils.extensions.navigateToAllFiles
 import com.nextcloud.utils.extensions.observeWorker
 import com.nextcloud.utils.fileNameValidator.FileNameValidator.checkFolderPath
 import com.nextcloud.utils.view.FastScrollUtils
+import com.nmc.android.utils.KeyboardUtils
 import com.owncloud.android.MainApp
 import com.owncloud.android.R
 import com.owncloud.android.databinding.FilesBinding
@@ -1348,6 +1349,8 @@ class FileDisplayActivity :
     private fun popBack() {
         binding.fabMain.setImageResource(R.drawable.ic_plus)
         resetScrolling(true)
+        // NMC: hide the keyboard on back press if showing
+        KeyboardUtils.hideKeyboardFrom(this, binding.root)
         showSortListGroup(false)
         supportFragmentManager.popBackStack()
     }

--- a/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ReceiveExternalFilesActivity.java
@@ -105,6 +105,7 @@ import java.util.Objects;
 import java.util.Stack;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -790,6 +791,10 @@ public class ReceiveExternalFilesActivity extends FileActivity
         }
 
         List<OCFile> files = getStorageManager().getFolderContent(mFile, false);
+
+        // NMC-2893 Task
+        // Filtering and showing only files which are folder
+        files = files.stream().filter(OCFile::isFolder).collect(Collectors.toList());
 
         if (files.isEmpty()) {
             setMessageForEmptyList(R.string.file_list_empty_headline, R.string.empty,

--- a/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.kt
@@ -14,6 +14,7 @@
 package com.owncloud.android.ui.activity
 
 import android.os.Bundle
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.account.User
@@ -130,14 +131,8 @@ class ShareActivity :
         if (file.isFolder) {
             val isAutoUploadFolder = SyncedFolderObserver.isAutoUploadFolder(file, user)
             val overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder)
-            binding.shareFileIcon.setImageDrawable(
-                MimeTypeUtil.getFolderIcon(
-                    preferences.isDarkModeEnabled(),
-                    overlayIconId,
-                    this,
-                    viewThemeUtils
-                )
-            )
+            // NMC Customization: No overlay icon will be used. Directly using folder icons
+            binding.shareFileIcon.setImageDrawable(ContextCompat.getDrawable(this, overlayIconId))
         } else {
             DisplayUtils.setThumbnail(
                 file,

--- a/app/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.nextcloud.client.account.User
 import com.owncloud.android.databinding.UploaderListItemLayoutBinding
@@ -115,10 +116,9 @@ class ReceiveExternalFilesAdapter(
 
     private fun setupThumbnailForFolder(thumbnailImageView: ImageView, file: OCFile) {
         val isAutoUploadFolder = SyncedFolderObserver.isAutoUploadFolder(file, user)
-        val isDarkModeActive = syncedFolderProvider.preferences.isDarkModeEnabled
         val overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder)
-        val icon = MimeTypeUtil.getFolderIcon(isDarkModeActive, overlayIconId, context, viewThemeUtils)
-        thumbnailImageView.setImageDrawable(icon)
+        // NMC Customization: No overlay icon will be used. Directly using folder icons
+        thumbnailImageView.setImageDrawable(ContextCompat.getDrawable(context, overlayIconId))
     }
 
     @Suppress("NestedBlockDepth")

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -34,6 +34,7 @@ import com.nextcloud.client.core.AsyncRunner
 import com.nextcloud.client.core.Clock
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.di.ViewModelFactory
+import com.nmc.android.utils.KeyboardUtils
 import com.nextcloud.client.network.ClientFactory
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.common.NextcloudClient
@@ -361,6 +362,8 @@ class UnifiedSearchFragment :
 
     private fun showFile(file: OCFile, showFileActions: Boolean, updateCurrentFile: Boolean = true) {
         (activity as? FileDisplayActivity)?.apply {
+            // NMC: hide keyboard when user taps on any file to view
+            KeyboardUtils.hideKeyboardFrom(requireContext(), binding.root)
             if (updateCurrentFile) {
                 this.file = file
             }
@@ -433,6 +436,7 @@ class UnifiedSearchFragment :
     }
 
     override fun onQueryTextSubmit(query: String): Boolean {
+        KeyboardUtils.hideKeyboardFrom(requireContext(), binding.root)
         vm.setQuery(query)
         vm.initialQuery()
         return true

--- a/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -16,7 +16,6 @@ import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
 import android.webkit.MimeTypeMap;
 
-import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.owncloud.android.R;
 import com.owncloud.android.datamodel.OCFile;
 import com.owncloud.android.lib.resources.files.model.ServerFileInterface;
@@ -94,18 +93,8 @@ public final class MimeTypeUtil {
                                            ViewThemeUtils viewThemeUtils) {
         if (context != null) {
             int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);
-            Drawable icon = ContextCompat.getDrawable(context, iconId);
-            if (icon == null) {
-                return null;
-            }
-
-            icon = icon.mutate();
-
-            if (R.drawable.file_zip == iconId) {
-                viewThemeUtils.platform.tintDrawable(context, icon, ColorRole.PRIMARY);
-            }
-
-            return icon;
+            //NMC Customization
+            return ContextCompat.getDrawable(context, iconId);
         } else {
             return null;
         }
@@ -119,11 +108,6 @@ public final class MimeTypeUtil {
         int iconId = determineIconIdByMimeTypeList(possibleMimeTypes);
 
         Drawable result = ContextCompat.getDrawable(context, iconId);
-        if (result == null) return null;
-
-        if (R.drawable.file_zip == iconId) {
-            viewThemeUtils.platform.tintDrawable(context, result, ColorRole.PRIMARY);
-        }
 
         return result;
     }
@@ -150,10 +134,12 @@ public final class MimeTypeUtil {
         Drawable drawable = ContextCompat.getDrawable(context, R.drawable.folder);
         assert(drawable != null);
 
-        viewThemeUtils.platform.tintDrawable(context, drawable, ColorRole.PRIMARY);
         return drawable;
     }
 
+    // NMC Note: This funtion won't be used in NMC as we are using different folder icons with inbuilt overlay. So this function is of no use for us.
+    // changed access to PRIVATE, in case if NC will use this function in more areas then we will get compile error which can be fixed by us
+    // so that UI won't be impacted.
     public static LayerDrawable getFolderIcon(boolean isDarkModeActive, Integer overlayIconId, Context context, ViewThemeUtils viewThemeUtils) {
         Drawable folderDrawable = getDefaultFolderIcon(context, viewThemeUtils);
         assert(folderDrawable != null);

--- a/app/src/main/java/com/owncloud/android/utils/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/owncloud/android/utils/overlay/OverlayManager.kt
@@ -56,10 +56,9 @@ class OverlayManager @Inject constructor(
 
         val isAutoUploadFolder =
             SyncedFolderObserver.isAutoUploadFolder(folder, accountManager.user)
-        val isDarkModeActive = preferences.isDarkModeEnabled()
 
         val overlayIconId = folder.getFileOverlayIconId(isAutoUploadFolder)
-        val icon = MimeTypeUtil.getFolderIcon(isDarkModeActive, overlayIconId, context, viewThemeUtils)
-        imageView.setImageDrawable(icon)
+        // NMC Customization: No overlay icon will be used. Directly using folder icons
+        imageView.setImageDrawable(ContextCompat.getDrawable(context, overlayIconId))
     }
 }


### PR DESCRIPTION
NMC-1922: Filtering only folders and showing them as per NMC-2893 Task
Update UnifiedSearchFragment.kt.
Commit id: 4fb3fb3 from branch bug/NMC-1652.

NMC-3192: ExoPlayer seek forward and backward customization.

NMC-2140: Tinting removed for folder and file icons and not overlaying icon for folders.
Share icon changed.
NMC-4749: fix favourite files loading properly by moving ui operation to main thread