### PR TITLE
General theming & customizations

### DIFF
--- a/app/src/androidTest/java/com/nmc/android/AppColorTest.kt
+++ b/app/src/androidTest/java/com/nmc/android/AppColorTest.kt
@@ -1,0 +1,363 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 TSI-mc <surinder.kumar@t-systems.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nmc.android
+
+import android.content.Context
+import android.content.res.Configuration
+import android.graphics.Color
+import androidx.core.content.ContextCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.owncloud.android.R
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test class to verify the colors customized in this branch PR for NMC
+ */
+@RunWith(AndroidJUnit4::class)
+class AppColorTest {
+    private val expectedColorMap = mapOf(
+        R.color.list_item_lastmod_and_filesize_text to ExpectedColor(
+            light = "#666666",
+            dark = "#B2B2B2"
+        ),
+        R.color.text_color to ExpectedColor(
+            light = "#191919",
+            dark = "#E3E3E3"
+        ),
+        R.color.light_grey to ExpectedColor(
+            light = "#F5F5F5",
+            dark = "#F5F5F5" // same for light and dark
+        ),
+        R.color.secondary_text_color to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#A5A5A5"
+        ),
+        R.color.action_mode_background to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#121212"
+        ),
+        R.color.selected_item_background to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#4C4C4C"
+        ),
+        R.color.drawer_active_item_background to ExpectedColor(
+            light = "#919191",
+            dark = "#FFFFFF"
+        ),
+        R.color.fontAppbar to ExpectedColor(
+            light = "#191919",
+            dark = "#FFFFFF"
+        ),
+        R.color.icon_color to ExpectedColor(
+            light = "#191919",
+            dark = "#FFFFFF"
+        ),
+        R.color.sort_text_color to ExpectedColor(
+            light = "#E20074", // primary magenta color
+            dark = "#B2B2B2"
+        ),
+        R.color.list_icon_color to ExpectedColor(
+            light = "#191919",
+            dark = "#B2B2B2"
+        ),
+        R.color.warning_icon_color to ExpectedColor(
+            light = "#191919",
+            dark = "#CCCCCC"
+        ),
+        R.color.divider_color to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#4C4C4C"
+        ),
+        R.color.spinner_bg_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#333333"
+        ),
+        R.color.refresh_layout_bg_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#2D2D2D"
+        ),
+        R.color.primary_button_disabled_color to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#4C4C4C"
+        ),
+        R.color.toolbar_divider_color to ExpectedColor(
+            light = "#CCCCCC",
+            dark = "#4C4C4C"
+        ),
+        R.color.et_highlight_color to ExpectedColor(
+            light = "#77c4ff",
+            dark = "#77c4ff" // same for light and dark
+        ),
+        R.color.white_trans_70 to ExpectedColor(
+            light = "#B3FFFFFF",
+            dark = "#B3FFFFFF" // same for light and dark
+        ),
+        R.color.progress_bar_background to ExpectedColor(
+            light = "#E5E5E5",
+            dark = "#E5E5E5" // same for light and dark
+        ),
+        R.color.dark_grey to ExpectedColor(
+            light = "#101010",
+            dark = "#101010" // same for light and dark
+        ),
+        R.color.grey_0 to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#F2F2F2" // same for light and dark
+        ),
+        R.color.grey_10 to ExpectedColor(
+            light = "#E5E5E5",
+            dark = "#E5E5E5" // same for light and dark
+        ),
+        R.color.grey_30 to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#B2B2B2" // same for light and dark
+        ),
+        R.color.grey_60 to ExpectedColor(
+            light = "#666666",
+            dark = "#666666" // same for light and dark
+        ),
+        R.color.grey_70 to ExpectedColor(
+            light = "#4C4C4C",
+            dark = "#4C4C4C" // same for light and dark
+        ),
+        R.color.grey_80 to ExpectedColor(
+            light = "#333333",
+            dark = "#333333" // same for light and dark
+        ),
+        R.color.snackbar_bg_color to ExpectedColor(
+            light = "#323232",
+            dark = "#333333"
+        ),
+        R.color.snackbar_txt_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#F2F2F2"
+        ),
+        R.color.alert_bg_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#333333"
+        ),
+        R.color.alert_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.nav_selected_bg_color to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#666666"
+        ),
+        R.color.nav_txt_unselected_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.nav_txt_selected_color to ExpectedColor(
+            light = "#E20074", // primary magenta color
+            dark = "#F2F2F2"
+        ),
+        R.color.nav_icon_unselected_color to ExpectedColor(
+            light = "#191919",
+            dark = "#B2B2B2"
+        ),
+        R.color.nav_icon_selected_color to ExpectedColor(
+            light = "#E20074", // primary magenta color
+            dark = "#FFFFFF"
+        ),
+        R.color.nav_divider_color to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#B2B2B2" // same for light and dark
+        ),
+        R.color.nav_bg_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#333333"
+        ),
+        R.color.drawer_quota_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#FFFFFF"
+        ),
+        R.color.bottom_sheet_bg_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#333333"
+        ),
+        R.color.bottom_sheet_icon_color to ExpectedColor(
+            light = "#191919",
+            dark = "#B2B2B2"
+        ),
+        R.color.bottom_sheet_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.popup_menu_bg to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#333333"
+        ),
+        R.color.popup_menu_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.overflow_bg_color to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#333333"
+        ),
+        R.color.switch_thumb_checked_enabled to ExpectedColor(
+            light = "#E20074", // primary magenta color
+            dark = "#E20074", // same for light and dark
+        ),
+        R.color.switch_track_checked_enabled to ExpectedColor(
+            light = "#F399C7",
+            dark = "#F399C7" // same for light and dark
+        ),
+        R.color.switch_thumb_unchecked_enabled to ExpectedColor(
+            light = "#FFFFFF",
+            dark = "#FFFFFF" // same for light and dark
+        ),
+        R.color.switch_track_unchecked_enabled to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#B2B2B2" // same for light and dark
+        ),
+        R.color.switch_thumb_disabled to ExpectedColor(
+            light = "#E5E5E5",
+            dark = "#4C4C4C"
+        ),
+        R.color.switch_track_disabled to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#666666"
+        ),
+        R.color.checkbox_checked_enabled to ExpectedColor(
+            light = "#E20074", // primary magenta color
+            dark = "#E20074", // same for light and dark
+        ),
+        R.color.checkbox_unchecked_enabled to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#B2B2B2" // same for light and dark
+        ),
+        R.color.checkbox_checked_disabled to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#4C4C4C"
+        ),
+        R.color.checkbox_unchecked_disabled to ExpectedColor(
+            light = "#CCCCCC",
+            dark = "#4C4C4C"
+        ),
+        R.color.share_title_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#FFFFFF"
+        ),
+        R.color.share_subtitle_txt_color to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#B2B2B2"
+        ),
+        R.color.share_info_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.share_search_border_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.share_btn_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.share_list_item_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.share_disabled_txt_color to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#666666"
+        ),
+        R.color.share_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.share_et_divider to ExpectedColor(
+            light = "#000000",
+            dark = "#FFFFFF"
+        ),
+        R.color.share_warning_txt_color to ExpectedColor(
+            light = "#191919",
+            dark = "#191919" // same for light and dark
+        ),
+        R.color.sharing_warning_bg_color to ExpectedColor(
+            light = "#F6E5EB",
+            dark = "#F6E5EB" // same for light and dark
+        ),
+        R.color.sharing_warning_border_color to ExpectedColor(
+            light = "#C16F81",
+            dark = "#C16F81" // same for light and dark
+        ),
+        R.color.share_color to ExpectedColor(
+            light = "#0D39DF",
+            dark = "#0D39DF" // same for light and dark
+        ),
+        R.color.shared_with_me_color to ExpectedColor(
+            light = "#0099ff",
+            dark = "#0099ff" // same for light and dark
+        ),
+        R.color.share_blue_color to ExpectedColor(
+            light = "#2238df",
+            dark = "#7d94f9"
+        ),
+        R.color.scan_doc_bg_color to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#121212"
+        ),
+        R.color.scan_text_color to ExpectedColor(
+            light = "#191919",
+            dark = "#F2F2F2"
+        ),
+        R.color.scan_edit_bottom_color to ExpectedColor(
+            light = "#F2F2F2",
+            dark = "#333333"
+        ),
+        R.color.scan_count_bg_color to ExpectedColor(
+            light = "#B2B2B2",
+            dark = "#333333"
+        ),
+        R.color.neptune to ExpectedColor(
+            light = "#77b6bb",
+            dark = "#77b6bb" // same for light and dark
+        ),
+        R.color.neptune_50 to ExpectedColor(
+            light = "#5077b6bb",
+            dark = "#5077b6bb" // same for light and dark
+        ),
+    )
+
+    @Test
+    fun validateLightModeColors() {
+        validateColors(Configuration.UI_MODE_NIGHT_NO) { Color.parseColor(it.light) }
+    }
+
+    @Test
+    fun validateDarkModeColors() {
+        validateColors(Configuration.UI_MODE_NIGHT_YES) { Color.parseColor(it.dark) }
+    }
+
+    private fun validateColors(
+        nightMode: Int,
+        expectedSelector: (ExpectedColor) -> Int
+    ) {
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        val conf = Configuration(appContext.resources.configuration)
+        conf.uiMode = (conf.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or nightMode
+        val ctx = appContext.createConfigurationContext(conf)
+
+        expectedColorMap.forEach { (colorRes, expectedColor) ->
+            val expected = expectedSelector(expectedColor)
+            val actual = ContextCompat.getColor(ctx, colorRes)
+            assertEquals(
+                "Color mismatch: ${ctx.resources.getResourceName(colorRes)}",
+                expected, actual
+            )
+        }
+    }
+
+    data class ExpectedColor(val light: String, val dark: String)
+}

--- a/app/src/androidTest/java/com/nmc/android/GeneralThemingResourceTest.kt
+++ b/app/src/androidTest/java/com/nmc/android/GeneralThemingResourceTest.kt
@@ -1,0 +1,275 @@
+/*
+ * Nextcloud - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 TSI-mc <surinder.kumar@t-systems.com>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package com.nmc.android
+
+import android.content.Context
+import android.content.res.Configuration
+import android.util.DisplayMetrics
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.owncloud.android.R
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+/**
+ * Test class to verify the strings, dimens and bool customized in this branch PR for NMC
+ */
+@RunWith(AndroidJUnit4::class)
+class GeneralThemingResourceTest {
+
+    private val baseContext = ApplicationProvider.getApplicationContext<Context>()
+
+    private val localizedStringMap = mapOf(
+        R.string.camera_permission_rationale to ExpectedLocalizedString(
+            translations = mapOf(
+                Locale.ENGLISH to "Please navigate to App info in settings and give permission manually.",
+                Locale.GERMAN to "Bitte geben Sie unter Apps & Benachrichtigungen in den Einstellungen manuell die Erlaubnis."
+            )
+        ),
+    )
+
+    @Test
+    fun verifyLocalizedStrings() {
+        localizedStringMap.forEach { (stringRes, expected) ->
+            expected.translations.forEach { (locale, expectedText) ->
+
+                val config = Configuration(baseContext.resources.configuration)
+                config.setLocale(locale)
+
+                val localizedContext = baseContext.createConfigurationContext(config)
+                val actualText = localizedContext.getString(stringRes)
+
+                assertEquals(
+                    "Mismatch for ${baseContext.resources.getResourceEntryName(stringRes)} in $locale",
+                    expectedText,
+                    actualText
+                )
+            }
+        }
+    }
+
+    data class ExpectedLocalizedString(val translations: Map<Locale, String>)
+
+    private val expectedDimenMap = mapOf(
+        R.dimen.grid_recyclerview_padding to ExpectedDimen(
+            default = 4f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.list_item_icons_size to ExpectedDimen(
+            default = 16f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.grid_item_icons_size to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.grid_item_shared_icon_layout_top_margin to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.media_grid_item_rv_spacing to ExpectedDimen(
+            default = 6f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.txt_size_18sp to ExpectedDimen(
+            default = 18f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.txt_size_15sp to ExpectedDimen(
+            default = 15f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.crop_corner_size to ExpectedDimen(
+            default = 15f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.edit_scan_bottom_bar_height to ExpectedDimen(
+            default = 56f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.standard_folders_grid_item_size to ExpectedDimen(
+            default = 86f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.standard_files_grid_item_size to ExpectedDimen(
+            default = 80f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.txt_size_11sp to ExpectedDimen(
+            default = 11f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.share_row_icon_size to ExpectedDimen(
+            default = 30f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.create_link_button_height to ExpectedDimen(
+            default = 55f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.note_et_height to ExpectedDimen(
+            default = 258f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.txt_size_17sp to ExpectedDimen(
+            default = 17f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.share_exp_date_divider_margin to ExpectedDimen(
+            default = 20f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.privacy_btn_width to ExpectedDimen(
+            default = 160f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.privacy_icon_size to ExpectedDimen(
+            default = 50f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.login_btn_width to ExpectedDimen(
+            default = 150f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.login_btn_height to ExpectedDimen(
+            default = 55f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.login_btn_bottom_margin to ExpectedDimen(
+            default = 48f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.login_btn_bottom_margin_land to ExpectedDimen(
+            default = 48f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.login_btn_bottom_margin_small_screen to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.shared_with_me_icon_size to ExpectedDimen(
+            default = 26f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.txt_size_20sp to ExpectedDimen(
+            default = 20f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.notification_row_item_height to ExpectedDimen(
+            default = 145f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.button_stroke_width to ExpectedDimen(
+            default = 1f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.txt_size_13sp to ExpectedDimen(
+            default = 13f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.file_icon_rounded_corner_radius_for_grid_mode to ExpectedDimen(
+            default = 4f,
+            unit = DimenUnit.DP,
+            alt = 16f
+        ),
+        R.dimen.file_icon_rounded_corner_radius to ExpectedDimen(
+            default = 8f,
+            unit = DimenUnit.DP,
+            alt = 32f
+        ),
+        R.dimen.grid_item_text_size to ExpectedDimen(
+            default = 14f,
+            unit = DimenUnit.SP
+        ),
+        R.dimen.grid_item_local_file_indicator_layout_width to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.grid_item_local_file_indicator_layout_height to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.list_item_local_file_indicator_layout_width to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+        R.dimen.list_item_local_file_indicator_layout_height to ExpectedDimen(
+            default = 24f,
+            unit = DimenUnit.DP
+        ),
+    )
+
+    @Test
+    fun validateDefaultDimens() {
+        validateDimens(
+            configModifier = { it }, // no change → default values
+        ) { it.default to it.unit }
+    }
+
+    @Test
+    fun validate_sw600dp_Dimens() {
+        validateDimens(configModifier = { config ->
+            config.smallestScreenWidthDp = 600
+            config
+        }) { it.alt to it.unit }
+    }
+
+    private fun validateDimens(
+        configModifier: (Configuration) -> Configuration,
+        selector: (ExpectedDimen) -> Pair<Float?, DimenUnit>
+    ) {
+        val baseConfig = Configuration(baseContext.resources.configuration)
+        val testConfig = configModifier(baseConfig)
+        val testContext = baseContext.createConfigurationContext(testConfig)
+        val dm = testContext.resources.displayMetrics
+        val config = testContext.resources.configuration
+        expectedDimenMap.forEach { (resId, entry) ->
+            val (value, unit) = selector(entry)
+            val actualPx = testContext.resources.getDimension(resId)
+            value?.let {
+                val expectedPx = convertToPx(value, unit, dm, config)
+                assertEquals(
+                    "Mismatch for ${testContext.resources.getResourceEntryName(resId)} ($unit)",
+                    expectedPx,
+                    actualPx,
+                    0.01f
+                )
+            }
+        }
+    }
+
+    private fun convertToPx(
+        value: Float,
+        unit: DimenUnit,
+        dm: DisplayMetrics,
+        config: Configuration
+    ): Float {
+        return when (unit) {
+            DimenUnit.DP -> value * dm.density
+            DimenUnit.SP -> value * dm.density * config.fontScale
+            DimenUnit.PX -> value
+        }
+    }
+
+    data class ExpectedDimen(
+        val default: Float,
+        val alt: Float? = null,
+        val unit: DimenUnit,
+    )
+
+    enum class DimenUnit { DP, SP, PX }
+
+    @Test
+    fun assertShowCalendarBackupBooleanFalse() {
+        val actualValue = baseContext.resources.getBoolean(R.bool.show_calendar_backup)
+        assertTrue(!actualValue)
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -290,6 +290,7 @@
             android:exported="false" />
         <activity
             android:name="com.nextcloud.client.widget.DashboardWidgetConfigurationActivity"
+            android:enabled="false"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
@@ -320,6 +321,7 @@
             android:exported="false" />
         <receiver
             android:name="com.nextcloud.client.widget.DashboardWidgetProvider"
+            android:enabled="false"
             android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -432,6 +434,7 @@
         <service
             android:name="com.nextcloud.client.widget.DashboardWidgetService"
             android:exported="true"
+            android:enabled="false"
             android:permission="android.permission.BIND_REMOTEVIEWS" />
 
         <provider

--- a/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
+++ b/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
@@ -118,7 +118,10 @@ abstract class NextcloudDatabase : RoomDatabase() {
     abstract fun capabilityDao(): CapabilityDao
 
     companion object {
-        const val FIRST_ROOM_DB_VERSION = 65
+        // NMC customization
+        // NMC play store version 7.21.9 had db version 64 before SqLite to Room migration
+        // Keeping it 65(as per NC) will lead to crash when user tried to upgrade the app
+        const val FIRST_ROOM_DB_VERSION = 64
         private var instance: NextcloudDatabase? = null
 
         @JvmStatic
@@ -139,6 +142,10 @@ abstract class NextcloudDatabase : RoomDatabase() {
                     .addMigrations(MIGRATION_88_89)
                     .addMigrations(MIGRATION_97_98)
                     .addMigrations(MIGRATION_99_100)
+                    // NMC-5368 & NMC-5364 fix
+                    // users upgrading from older sqlite or room version i.e. 62 or 64
+                    // the migration fails and app crashes
+                    .fallbackToDestructiveMigration(true)
                     .build()
             }
             return instance!!

--- a/app/src/main/java/com/nextcloud/client/editimage/EditImageActivity.kt
+++ b/app/src/main/java/com/nextcloud/client/editimage/EditImageActivity.kt
@@ -8,6 +8,7 @@
 package com.nextcloud.client.editimage
 
 import android.graphics.Bitmap
+import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -15,9 +16,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.core.graphics.drawable.DrawableCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.core.content.ContextCompat
 import com.canhub.cropper.CropImageView
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.jobs.upload.FileUploadHelper
@@ -70,18 +69,23 @@ class EditImageActivity :
         file = intent.extras?.getParcelableArgument(EXTRA_FILE, OCFile::class.java)
             ?: throw IllegalArgumentException("Missing file argument")
 
-        setSupportActionBar(binding.toolbar)
-        supportActionBar?.apply {
-            title = file.fileName
-            setDisplayHomeAsUpEnabled(true)
-        }
-
-        val windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
-        windowInsetsController.hide(WindowInsetsCompat.Type.statusBars())
-
-        window.navigationBarColor = getColor(R.color.black)
+        // NMC Customization
+        setupToolbar()
+        setupActionBar()
 
         setupCropper()
+    }
+
+    //NMC Customization
+    private fun setupActionBar() {
+        supportActionBar?.let {
+            viewThemeUtils.platform.themeStatusBar(this)
+            it.setDisplayHomeAsUpEnabled(true)
+            it.setDisplayShowTitleEnabled(true)
+            //custom color for back arrow for NMC
+            viewThemeUtils.files.themeActionBar(this, it, file.fileName)
+            it.setBackgroundDrawable(ColorDrawable(resources.getColor(R.color.bg_default, null)))
+        }
     }
 
     override fun onCropImageComplete(view: CropImageView, result: CropImageView.CropResult) {
@@ -120,12 +124,18 @@ class EditImageActivity :
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         // add save button to action bar
         menuInflater.inflate(R.menu.custom_menu_placeholder, menu)
-        val saveIcon = AppCompatResources.getDrawable(this, R.drawable.ic_check)?.also {
-            DrawableCompat.setTint(it, resources.getColor(R.color.white, theme))
-        }
+        // NMC: No need to apply NC tint here as we will be doing it later in code
+        val saveIcon = AppCompatResources.getDrawable(this, R.drawable.ic_tick)
         menu?.findItem(R.id.custom_menu_placeholder_item)?.apply {
             icon = saveIcon
             contentDescription = getString(R.string.common_save)
+            // NMC customization
+            icon = icon?.let {
+                viewThemeUtils.platform.colorDrawable(
+                    it,
+                    ContextCompat.getColor(this@EditImageActivity, R.color.fontAppbar)
+                )
+            }
         }
         return true
     }

--- a/app/src/main/java/com/nextcloud/client/errorhandling/ShowErrorActivity.kt
+++ b/app/src/main/java/com/nextcloud/client/errorhandling/ShowErrorActivity.kt
@@ -35,14 +35,16 @@ class ShowErrorActivity : AppCompatActivity() {
         setSupportActionBar(binding.toolbarInclude.toolbar)
         supportActionBar!!.title = createErrorTitle()
 
-        val snackbar = DisplayUtils.createSnackbar(
+        // NMC-4862
+        // deactivate github report snackbar
+        /* val snackbar = DisplayUtils.createSnackbar(
             binding.errorPageContainer,
             R.string.error_report_issue_text,
             Snackbar.LENGTH_INDEFINITE
         )
             .setAction(R.string.error_report_issue_action) { reportIssue() }
 
-        snackbar.show()
+        snackbar.show() */
     }
 
     private fun createErrorTitle() = String.format(getString(R.string.error_crash_title), getString(R.string.app_name))

--- a/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/fileactions/FileActionsBottomSheet.kt
@@ -160,7 +160,8 @@ class FileActionsBottomSheet :
                 binding.thumbnailLayout.thumbnailShimmer,
                 syncedFolderProvider.preferences,
                 viewThemeUtils,
-                overlayManager
+                overlayManager,
+                false
             )
         }
     }

--- a/app/src/main/java/com/nextcloud/ui/trashbinFileActions/TrashbinFileActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/ui/trashbinFileActions/TrashbinFileActionsBottomSheet.kt
@@ -133,7 +133,8 @@ class TrashbinFileActionsBottomSheet :
                 binding.thumbnailLayout.thumbnailShimmer,
                 syncedFolderProvider.preferences,
                 viewThemeUtils,
-                overlayManager
+                overlayManager,
+                false
             )
         }
     }

--- a/app/src/main/java/com/nmc/android/ui/utils/Log_NMC.kt
+++ b/app/src/main/java/com/nmc/android/ui/utils/Log_NMC.kt
@@ -1,0 +1,42 @@
+package com.nmc.android.ui.utils
+
+import com.owncloud.android.BuildConfig
+import com.owncloud.android.lib.common.utils.Log_OC
+
+/**
+ * NMC log interpreter class
+ * this class will be used whenever we have to reduce the logs writing
+ * this will avoid printing logs in release builds
+ * todo: can be extended later for more functions
+ */
+object Log_NMC {
+    @JvmStatic
+    fun v(tag: String?, msg: String?) {
+        if (BuildConfig.DEBUG) Log_OC.v(tag, msg)
+    }
+
+    @JvmStatic
+    fun d(tag: String?, msg: String?) {
+        if (BuildConfig.DEBUG) Log_OC.d(tag, msg)
+    }
+
+    @JvmStatic
+    fun d(tag: String, msg: String, e: Exception) {
+        if (BuildConfig.DEBUG) Log_OC.d(tag, msg, e)
+    }
+
+    @JvmStatic
+    fun i(tag: String?, msg: String?) {
+        if (BuildConfig.DEBUG) Log_OC.i(tag, msg)
+    }
+
+    @JvmStatic
+    fun e(tag: String?, msg: String?) {
+        if (BuildConfig.DEBUG) Log_OC.e(tag, msg)
+    }
+
+    @JvmStatic
+    fun w(tag: String?, msg: String?) {
+        if (BuildConfig.DEBUG) Log_OC.w(tag, msg)
+    }
+}

--- a/app/src/main/java/com/owncloud/android/MainApp.java
+++ b/app/src/main/java/com/owncloud/android/MainApp.java
@@ -1012,11 +1012,8 @@ public class MainApp extends Application implements HasAndroidInjector, NetworkC
     }
 
     public static void setAppTheme(DarkMode mode) {
-        switch (mode) {
-            case LIGHT -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
-            case DARK -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-            case SYSTEM -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
-        }
+        // NMC Customization -> Always follow system theme
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/datamodel/MediaProvider.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/MediaProvider.java
@@ -12,8 +12,8 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.MediaStore;
 
+import com.nmc.android.ui.utils.Log_NMC;
 import com.owncloud.android.MainApp;
-import com.owncloud.android.lib.common.utils.Log_OC;
 import com.owncloud.android.utils.PermissionUtil;
 import com.owncloud.android.utils.theme.ViewThemeUtils;
 
@@ -106,7 +106,7 @@ public final class MediaProvider {
                                                                    MediaStore.Images.Media.DATE_TAKEN,
                                                                    ContentResolverHelper.SORT_DIRECTION_DESCENDING,
                                                                    itemLimit);
-                Log_OC.d(TAG, "Reading images for " + mediaFolder.folderName);
+                Log_NMC.d(TAG, "Reading images for " + mediaFolder.folderName);
 
                 if (cursorImages != null) {
                     String filePath;
@@ -214,7 +214,7 @@ public final class MediaProvider {
                                                                    ContentResolverHelper.SORT_DIRECTION_DESCENDING,
                                                                    itemLimit);
 
-                Log_OC.d(TAG, "Reading videos for " + mediaFolder.folderName);
+                Log_NMC.d(TAG, "Reading videos for " + mediaFolder.folderName);
 
                 if (cursorVideos != null) {
                     String filePath;

--- a/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
+++ b/app/src/main/java/com/owncloud/android/datamodel/ThumbnailsCacheManager.java
@@ -40,6 +40,7 @@ import com.nextcloud.client.network.ConnectivityService;
 import com.nextcloud.utils.BitmapExtensionsKt;
 import com.nextcloud.utils.extensions.OCFileExtensionsKt;
 import com.nextcloud.utils.extensions.OwnCloudClientExtensionsKt;
+import com.nmc.android.ui.utils.Log_NMC;
 import com.owncloud.android.MainApp;
 import com.owncloud.android.R;
 import com.owncloud.android.lib.common.OwnCloudAccount;
@@ -135,7 +136,7 @@ public final class ThumbnailsCacheManager {
                         }
 
                         String cachePath = cacheDir.getPath() + File.separator + CACHE_FOLDER;
-                        Log_OC.d(TAG, "thumbnail cache dir: " + cachePath);
+                        Log_NMC.d(TAG, "thumbnail cache dir: " + cachePath);
                         File diskCacheDir = new File(cachePath);
 
                         // migrate from external cache to internal cache
@@ -152,7 +153,7 @@ public final class ThumbnailsCacheManager {
                         mThumbnailCache = new DiskLruImageCache(diskCacheDir, DISK_CACHE_SIZE, mCompressFormat,
                                                                 mCompressQuality);
                     } catch (Exception e) {
-                        Log_OC.d(TAG, "Disk cache init failed", e);
+                        Log_NMC.d(TAG, "Disk cache init failed", e);
                         mThumbnailCache = null;
                     }
                 }
@@ -435,6 +436,7 @@ public final class ThumbnailsCacheManager {
         private GetMethod getMethod;
         private Listener mListener;
         private boolean gridViewEnabled = false;
+        private boolean hideVideoOverlay = false;
 
         public ThumbnailGenerationTask(ImageView imageView, FileDataStorageManager storageManager, User user)
                 throws IllegalArgumentException {
@@ -459,11 +461,13 @@ public final class ThumbnailsCacheManager {
                                        User user,
                                        List<ThumbnailGenerationTask> asyncTasks,
                                        boolean gridViewEnabled,
-                                       String imageKey)
+                                       String imageKey,
+                                       boolean hideVideoOverlay)
             throws IllegalArgumentException {
             this(imageView, storageManager, user, asyncTasks);
             this.gridViewEnabled = gridViewEnabled;
             mImageKey = imageKey;
+            this.hideVideoOverlay = hideVideoOverlay;
         }
 
         public GetMethod getGetMethod() {
@@ -506,7 +510,7 @@ public final class ThumbnailsCacheManager {
                 if (mFile instanceof ServerFileInterface) {
                     thumbnail = doThumbnailFromOCFileInBackground();
 
-                    if (MimeTypeUtil.isVideo((ServerFileInterface) mFile) && thumbnail != null) {
+                    if (MimeTypeUtil.isVideo((ServerFileInterface) mFile) && thumbnail != null && !hideVideoOverlay) {
                         thumbnail = addVideoOverlay(thumbnail, MainApp.getAppContext());
                     }
                 } else if (mFile instanceof File) {
@@ -515,7 +519,7 @@ public final class ThumbnailsCacheManager {
                     String url = ((File) mFile).getAbsolutePath();
                     String mMimeType = FileStorageUtils.getMimeTypeFromName(url);
 
-                    if (MimeTypeUtil.isVideo(mMimeType) && thumbnail != null) {
+                    if (MimeTypeUtil.isVideo(mMimeType) && thumbnail != null && !hideVideoOverlay) {
                         thumbnail = addVideoOverlay(thumbnail, MainApp.getAppContext());
                     }
                     //} else {  do nothing
@@ -583,13 +587,13 @@ public final class ThumbnailsCacheManager {
             if (!updateEnforced) {
                 thumbnail = getBitmapFromDiskCache(imageKey);
                 if (thumbnail != null) {
-                    Log_OC.d(TAG, "Thumbnail found in disk cache for file: " + file.getFileName());
+                    Log_NMC.d(TAG, "Thumbnail found in disk cache for file: " + file.getFileName());
                     return thumbnail;
                 } else {
-                    Log_OC.d(TAG, "Thumbnail not found in cache for file: " + file.getFileName());
+                    Log_NMC.d(TAG, "Thumbnail not found in cache for file: " + file.getFileName());
                 }
             } else {
-                Log_OC.d(TAG, "Thumbnail update enforced for file: " + file.getFileName());
+                Log_NMC.d(TAG, "Thumbnail update enforced for file: " + file.getFileName());
                 thumbnail = null;
             }
 
@@ -599,7 +603,7 @@ public final class ThumbnailsCacheManager {
 
             // Generate thumbnail from local file if available
             if (file instanceof OCFile ocFile && ocFile.isDown()) {
-                Log_OC.d(TAG, "Generating thumbnail from local file: " + ocFile.getFileName());
+                Log_NMC.d(TAG, "Generating thumbnail from local file: " + ocFile.getFileName());
 
                 Bitmap bitmap;
                 if (MimeTypeUtil.isVideo(ocFile)) {
@@ -631,15 +635,15 @@ public final class ThumbnailsCacheManager {
 
                 if (resizedImage != null) {
                     thumbnail = ThumbnailUtils.extractThumbnail(resizedImage, pxW, pxH);
-                    Log_OC.d(TAG, "Thumbnail generated from resized image cache for file: " + file.getFileName());
+                    Log_NMC.d(TAG, "Thumbnail generated from resized image cache for file: " + file.getFileName());
                 } else {
-                    Log_OC.d(TAG, "No resized image cache available for file: " + file.getFileName());
+                    Log_NMC.d(TAG, "No resized image cache available for file: " + file.getFileName());
                 }
             }
 
             // Download thumbnail from server if still null
             if (thumbnail == null && mClient != null) {
-                Log_OC.d(TAG, "Attempting to download thumbnail from server for file: " + file.getFileName());
+                Log_NMC.d(TAG, "Attempting to download thumbnail from server for file: " + file.getFileName());
                 GetMethod getMethod = null;
 
                 try {
@@ -653,7 +657,7 @@ public final class ThumbnailsCacheManager {
                             + file.getLocalId() + "&x=" + pxW + "&y=" + pxH;
                     }
 
-                    Log_OC.d(TAG, "Downloading thumbnail URI: " + uri);
+                    Log_NMC.d(TAG, "Downloading thumbnail URI: " + uri);
 
                     getMethod = new GetMethod(uri);
                     getMethod.setRequestHeader("Cookie", "nc_sameSiteCookielax=true;nc_sameSiteCookiestrict=true");
@@ -666,9 +670,9 @@ public final class ThumbnailsCacheManager {
                             Bitmap bitmap = BitmapFactory.decodeStream(inputStream);
                             if (bitmap != null) {
                                 thumbnail = ThumbnailUtils.extractThumbnail(bitmap, pxW, pxH);
-                                Log_OC.d(TAG, "Thumbnail downloaded and extracted for file: " + file.getFileName());
+                                Log_NMC.d(TAG, "Thumbnail downloaded and extracted for file: " + file.getFileName());
                             } else {
-                                Log_OC.w(TAG, "Downloaded thumbnail bitmap is null for file: " + file.getFileName());
+                                Log_NMC.w(TAG, "Downloaded thumbnail bitmap is null for file: " + file.getFileName());
                             }
                         }
                     } else {
@@ -678,7 +682,7 @@ public final class ThumbnailsCacheManager {
 
                     if (thumbnail != null && PNG_MIMETYPE.equalsIgnoreCase(file.getMimeType())) {
                         thumbnail = handlePNG(thumbnail, pxW, pxH);
-                        Log_OC.d(TAG, "Handled PNG thumbnail for downloaded file: " + file.getFileName());
+                        Log_NMC.d(TAG, "Handled PNG thumbnail for downloaded file: " + file.getFileName());
                     }
                 } catch (Exception e) {
                     Log_OC.e(TAG, "Exception downloading thumbnail for file: " + file.getFileName(), e);
@@ -691,10 +695,10 @@ public final class ThumbnailsCacheManager {
 
             // Add to disk cache if obtained
             if (thumbnail != null) {
-                Log_OC.d(TAG, "Adding final thumbnail to cache for file: " + file.getFileName());
+                Log_NMC.d(TAG, "Adding final thumbnail to cache for file: " + file.getFileName());
                 addBitmapToCache(imageKey, thumbnail);
             } else {
-                Log_OC.w(TAG, "Failed to obtain thumbnail for file: " + file.getFileName());
+                Log_NMC.w(TAG, "Failed to obtain thumbnail for file: " + file.getFileName());
             }
 
             return thumbnail;
@@ -849,7 +853,7 @@ public final class ThumbnailsCacheManager {
                         thumbnail = retriever.getFrameAtTime(-1);
                     } catch (Exception ex) {
                         // can't create a bitmap
-                        Log_OC.w(TAG, "Failed to create bitmap from video " + file.getAbsolutePath());
+                        Log_NMC.w(TAG, "Failed to create bitmap from video " + file.getAbsolutePath());
                     }
 
                     if (thumbnail != null) {
@@ -956,7 +960,7 @@ public final class ThumbnailsCacheManager {
 
                     int px = mResources.getInteger(R.integer.file_avatar_px);
                     String uri = mClient.getBaseUri() + "/index.php/avatar/" + Uri.encode(mUserId) + "/" + px;
-                    Log_OC.d("Avatar", "URI: " + uri);
+                    Log_NMC.d("Avatar", "URI: " + uri);
                     get = new GetMethod(uri);
 
                     // only use eTag if available and corresponding avatar is still there
@@ -1209,7 +1213,7 @@ public final class ThumbnailsCacheManager {
             String uri = client.getBaseUri() + "/index.php/apps/files/api/v1/thumbnail/" +
                 pxW + "/" + pxH + Uri.encode(file.getRemotePath(), "/");
 
-            Log_OC.d(TAG, "generate thumbnail: " + file.getFileName() + " URI: " + uri);
+            Log_NMC.d(TAG, "generate thumbnail: " + file.getFileName() + " URI: " + uri);
             getMethod = new GetMethod(uri);
             getMethod.setRequestHeader("Cookie", "nc_sameSiteCookielax=true;nc_sameSiteCookiestrict=true");
 
@@ -1232,7 +1236,7 @@ public final class ThumbnailsCacheManager {
                     thumbnail = handlePNG(thumbnail, pxW, pxH);
                 }
 
-                Log_OC.d(TAG, "add thumbnail to cache: " + file.getFileName());
+                Log_NMC.d(TAG, "add thumbnail to cache: " + file.getFileName());
                 addBitmapToCache(imageKey, thumbnail);
             }
         } catch (Exception e) {
@@ -1287,7 +1291,7 @@ public final class ThumbnailsCacheManager {
 
             try {
                 String uri = OwnCloudClientExtensionsKt.getPreviewEndpoint(mClient, file.getRemoteId(), pxW, pxH);
-                Log_OC.d(TAG, "generating resized image: " + file.getFileName() + " URI: " + uri);
+                Log_NMC.d(TAG, "generating resized image: " + file.getFileName() + " URI: " + uri);
 
                 getMethod = new GetMethod(uri);
                 getMethod.getParams().setSoTimeout(READ_TIMEOUT);

--- a/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/FileDisplayActivity.kt
@@ -516,6 +516,9 @@ class FileDisplayActivity :
                             fragment.directCameraUpload()
                         }
                     })
+                } else if (!shouldShowRequestPermissionRationale(permissions[0])) {
+                    // user CHECKED "never ask again"
+                    DisplayUtils.showSnackMessage(this, R.string.camera_permission_rationale)
                 }
 
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/PassCodeActivity.kt
@@ -21,7 +21,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
-import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.client.di.Injectable
 import com.nextcloud.client.preferences.AppPreferences
 import com.nextcloud.utils.extensions.setVisibleIf
@@ -89,7 +88,6 @@ class PassCodeActivity :
         setContentView(binding.root)
 
         PassCodeManager.setSecureFlag(this, true)
-        applyTint()
         setupPasscodeEditTexts()
         setSoftInputMode()
         setupUI(savedInstanceState)
@@ -110,22 +108,11 @@ class PassCodeActivity :
         )
     }
 
-    private fun applyTint() {
-        viewThemeUtils.platform.colorViewBackground(binding.cardViewContent, ColorRole.SURFACE_VARIANT)
-        viewThemeUtils.material.colorMaterialButtonPrimaryBorderless(binding.cancel)
-    }
-
     private fun setupPasscodeEditTexts() {
         passCodeEditTexts[0] = binding.txt0
         passCodeEditTexts[1] = binding.txt1
         passCodeEditTexts[2] = binding.txt2
         passCodeEditTexts[3] = binding.txt3
-
-        passCodeEditTexts.forEach {
-            it?.let { editText ->
-                viewThemeUtils.platform.colorEditText(editText)
-            }
-        }
 
         passCodeEditTexts[0]?.requestFocus()
 

--- a/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.kt
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.kt
@@ -23,6 +23,7 @@ import com.owncloud.android.databinding.ShareActivityBinding
 import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.SyncedFolderObserver
 import com.owncloud.android.datamodel.SyncedFolderProvider
+import com.owncloud.android.datamodel.ThumbnailsCacheManager.ThumbnailGenerationTask
 import com.owncloud.android.lib.common.operations.RemoteOperation
 import com.owncloud.android.lib.common.operations.RemoteOperationResult
 import com.owncloud.android.lib.common.utils.Log_OC
@@ -144,13 +145,14 @@ class ShareActivity :
                 binding.shareFileIcon,
                 user,
                 storageManager,
-                mutableListOf(),
+                mutableListOf<ThumbnailGenerationTask>(),
                 false,
                 this,
                 null,
                 preferences,
                 viewThemeUtils,
-                overlayManager
+                overlayManager,
+                false
             )
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryAdapter.kt
@@ -88,7 +88,8 @@ class GalleryAdapter(
             transferServiceGetter,
             showMetadata = false,
             showShareAvatar = false,
-            viewThemeUtils
+            viewThemeUtils,
+            true
         )
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/adapter/GalleryRowHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/GalleryRowHolder.kt
@@ -48,9 +48,8 @@ class GalleryRowHolder(
     private val checkBoxMargin by lazy { context.resources.getDimension(R.dimen.standard_quarter_padding) }
 
     private val checkedDrawable by lazy {
-        ContextCompat.getDrawable(context, R.drawable.ic_checkbox_marked)?.also {
-            viewThemeUtils.platform.tintDrawable(context, it, ColorRole.PRIMARY)
-        }
+        // NMC Customization: no need to tint the color
+        ContextCompat.getDrawable(context, R.drawable.ic_checkbox_marked)
     }
 
     private val uncheckedDrawable by lazy {
@@ -92,8 +91,9 @@ class GalleryRowHolder(
                 FrameLayout.LayoutParams.WRAP_CONTENT,
                 FrameLayout.LayoutParams.WRAP_CONTENT
             ).apply {
-                gravity = Gravity.TOP or Gravity.START
-                marginStart = checkBoxMargin.toInt()
+                // NMC Customization: align checkbox on top right
+                gravity = Gravity.TOP or Gravity.END
+                marginEnd = checkBoxMargin.toInt()
                 topMargin = checkBoxMargin.toInt()
             }
         }
@@ -175,8 +175,10 @@ class GalleryRowHolder(
 
     @Suppress("MagicNumber")
     private fun adjustRowCell(imageView: ImageView, isChecked: Boolean) {
-        val scale = if (isChecked) 0.8f else 1.0f
-        val radius = if (isChecked) iconRadius else 0f
+        // NMC Customization: no need to scaling and rounding
+        // we want a normal view without any corners
+        val scale = 1.0f
+        val radius = 0f
         imageView.scaleX = scale
         imageView.scaleY = scale
         imageView.makeRounded(context, radius)

--- a/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/LocalFileListAdapter.java
@@ -231,9 +231,8 @@ public class LocalFileListAdapter extends RecyclerView.Adapter<RecyclerView.View
                 grid.itemLayout.setBackgroundColor(
                     ContextCompat.getColor(mContext, R.color.selected_item_background)
                                                   );
-                grid.checkbox.setImageDrawable(
-                    viewThemeUtils.platform.tintDrawable(mContext, R.drawable.ic_checkbox_marked, ColorRole.PRIMARY)
-                                              );
+                // NMC Customization
+                grid.checkbox.setImageResource(R.drawable.ic_checkbox_marked);
             } else {
                 grid.itemLayout.setBackgroundColor(
                     mContext.getResources().getColor(R.color.bg_default)

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListAdapter.java
@@ -187,6 +187,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                                                     true,
                                                     true,
                                                     viewThemeUtils,
+                                                    false,
                                                     syncedFolderProvider);
 
         setHasStableIds(true);
@@ -412,6 +413,8 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
                 return new OCFileListHeaderViewHolder(binding);
             }
+            // change required for NMC
+            // default case will be used for VIEW_TYPE_IMAGE & VIEWTYPE_ITEM also
             default -> {
                 if (gridView) {
                     return new OCFileListGridItemViewHolder(
@@ -430,7 +433,6 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof OCFileListFooterViewHolder footerViewHolder) {
             footerViewHolder.getFooterText().setText(getFooterText());
-            viewThemeUtils.platform.colorCircularProgressBar(footerViewHolder.getLoadingProgressBar(), ColorRole.ON_SURFACE_VARIANT);
             footerViewHolder.getLoadingProgressBar().setVisibility(
                 ocFileListFragmentInterface.isLoading() ? View.VISIBLE : View.GONE);
         } else if (holder instanceof OCFileListHeaderViewHolder headerViewHolder) {
@@ -1022,6 +1024,7 @@ public class OCFileListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     public void setGridView(boolean bool) {
         gridView = bool;
+        ocFileListDelegate.setGridView(bool);
     }
 
     public void setShowMetadata(boolean bool) {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListDelegate.kt
@@ -55,11 +55,12 @@ class OCFileListDelegate(
     private val storageManager: FileDataStorageManager,
     private val hideItemOptions: Boolean,
     private val preferences: AppPreferences,
-    private val gridView: Boolean,
+    private var gridView: Boolean,
     private val transferServiceGetter: ComponentsGetter,
     private val showMetadata: Boolean,
     private var showShareAvatar: Boolean,
     private var viewThemeUtils: ViewThemeUtils,
+    private val isMediaGallery: Boolean,
     private val syncFolderProvider: SyncedFolderProvider? = null
 ) {
     private val tag = "OCFileListDelegate"
@@ -198,7 +199,8 @@ class OCFileListDelegate(
             shimmerThumbnail,
             preferences,
             viewThemeUtils,
-            overlayManager
+            overlayManager,
+            isMediaGallery
         )
     }
 
@@ -233,22 +235,15 @@ class OCFileListDelegate(
 
         // shares
         val shouldHideShare = (
-            (
+            gridView || // NMC: don't show share icon in grid mode
                 hideItemOptions ||
-                    (
-                        !file.isFolder &&
-                            file.isEncrypted
-                        ) ||
-                    (
-                        file.isEncrypted &&
-                            !EncryptionUtils.supportsSecureFiledrop(file, user)
-                        ) ||
-                    (searchType == SearchType.FAVORITE_SEARCH) ||
-                    (
-                        file.isFolder &&
-                            (currentDirectory?.isEncrypted ?: false)
-                        )
-                )
+                !file.isFolder &&
+                file.isEncrypted ||
+                file.isEncrypted &&
+                !EncryptionUtils.supportsSecureFiledrop(file, user) ||
+                searchType == SearchType.FAVORITE_SEARCH ||
+                file.isFolder &&
+                currentDirectory?.isEncrypted ?: false
             ) // sharing an encrypted subfolder is not possible
         if (shouldHideShare) {
             viewHolder.shared.visibility = View.GONE
@@ -322,9 +317,8 @@ class OCFileListDelegate(
 
     private fun setCheckBoxImage(file: OCFile, gridViewHolder: ListViewHolder) {
         if (isCheckedFile(file)) {
-            gridViewHolder.checkbox.setImageDrawable(
-                viewThemeUtils.platform.tintDrawable(context, R.drawable.ic_checkbox_marked, ColorRole.PRIMARY)
-            )
+            // NMC Customization
+            gridViewHolder.checkbox.setImageResource(R.drawable.ic_checkbox_marked)
         } else {
             gridViewHolder.checkbox.setImageResource(R.drawable.ic_checkbox_blank_outline)
         }
@@ -449,6 +443,10 @@ class OCFileListDelegate(
         cancelAllPendingTasks()
 
         Log_OC.d(TAG, "background jobs cancelled")
+    }
+
+    fun setGridView(bool: Boolean){
+        gridView = bool
     }
 
     companion object {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListGridItemViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListGridItemViewHolder.kt
@@ -65,8 +65,8 @@ class OCFileListGridItemViewHolder(var binding: GridItemBinding) :
     override val hasVisibleFeatureIndicators: Boolean
         get() = localFileIndicator.isVisible || gridLivePhotoIndicator?.isVisible == true || unreadComments.isVisible ||
             shared.isVisible || binding.videoOverlay.isVisible || favorite.isVisible
-    override val fileFeaturesLayout: LinearLayout
-        get() = binding.fileFeaturesLayout
+    override val fileFeaturesLayout: LinearLayout?
+        get() = null
     override val more: ImageButton
         get() = if (binding.bidiFilenameContainer.isVisible) {
             binding.bidiMore

--- a/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/OCFileListViewHolder.kt
@@ -57,8 +57,8 @@ internal class OCFileListViewHolder(var binding: GridItemBinding) :
         } else {
             binding.more
         }
-    override val fileFeaturesLayout: LinearLayout
-        get() = binding.fileFeaturesLayout
+    override val fileFeaturesLayout: LinearLayout?
+        get() = null
     override val gridLivePhotoIndicator: ImageView
         get() = binding.gridLivePhotoIndicator
     override val livePhotoIndicator: TextView?

--- a/app/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/TrashbinListAdapter.java
@@ -17,7 +17,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
-import com.nextcloud.android.common.ui.theme.utils.ColorRole;
 import com.nextcloud.client.account.User;
 import com.nextcloud.client.preferences.AppPreferences;
 import com.nextcloud.utils.extensions.ViewExtensionsKt;
@@ -153,8 +152,8 @@ public class TrashbinListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             // checkbox
             if (isCheckedFile(file)) {
-                trashbinFileViewHolder.binding.customCheckbox.setImageDrawable(
-                    viewThemeUtils.platform.tintDrawable(context, R.drawable.ic_checkbox_marked, ColorRole.PRIMARY));
+                // NMC Customization
+                trashbinFileViewHolder.binding.customCheckbox.setImageResource(R.drawable.ic_checkbox_marked);
             } else {
                 trashbinFileViewHolder.binding.customCheckbox.setImageResource(R.drawable.ic_checkbox_blank_outline);
             }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchCurrentDirItemViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchCurrentDirItemViewHolder.kt
@@ -59,7 +59,8 @@ class UnifiedSearchCurrentDirItemViewHolder(
             binding.thumbnailShimmer,
             appPreferences,
             viewThemeUtils,
-            overlayManager
+            overlayManager,
+            false
         )
 
         binding.more.setOnClickListener {

--- a/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchItemViewHolder.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/UnifiedSearchItemViewHolder.kt
@@ -124,7 +124,9 @@ class UnifiedSearchItemViewHolder(
                 user,
                 preferences,
                 context,
-                viewThemeUtils
+                viewThemeUtils,
+                false,
+                false
             )
         }
     }

--- a/app/src/main/java/com/owncloud/android/ui/adapter/uploadList/UploadListAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/uploadList/UploadListAdapter.kt
@@ -109,7 +109,8 @@ class UploadListAdapter(
         val title = activity.getString(group.titleRes)
         val headerText = activity.getString(R.string.uploads_view_group_header)
         holder.binding.uploadListTitle.text = String.format(headerText, title, group.items.size)
-        viewThemeUtils.platform.colorTextView(holder.binding.uploadListTitle)
+        // NMC Customization
+        holder.binding.uploadListTitle.setTextColor(activity.getResources().getColor(R.color.primary, null))
 
         val toggleExpand = {
             toggleSectionExpanded(section)

--- a/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ConflictsResolveDialog.kt
@@ -236,7 +236,8 @@ class ConflictsResolveDialog :
             null,
             syncedFolderProvider.preferences,
             viewThemeUtils,
-            overlayManager
+            overlayManager,
+            false
         )
     }
 

--- a/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/OCFileListFragment.java
@@ -1682,6 +1682,16 @@ public class OCFileListFragment extends ExtendedListFragment implements
         return currentSearchType;
     }
 
+    //NMC Customization
+    //for NMC we are using defaultToolbar instead searchToolbar for which we needed customization
+    private boolean isRoot() {
+        Activity activity;
+        if ((activity = getActivity()) != null && activity instanceof FileDisplayActivity) {
+            return ((FileDisplayActivity) activity).isRoot(((FileDisplayActivity) activity).getFile());
+        }
+        return false;
+    }
+
     protected void prepareActionBarItems(SearchEvent event) {
         if (event != null) {
             switch (event.getSearchType()) {

--- a/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/UnifiedSearchFragment.kt
@@ -170,9 +170,10 @@ class UnifiedSearchFragment :
         super.onViewCreated(view, savedInstanceState)
 
         setupAdapter()
-        if (supportsOpeningCalendarContactsLocally()) {
+        // NMC-4633 disable permission check
+        /*if (supportsOpeningCalendarContactsLocally()) {
             checkPermissions()
-        }
+        }*/
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/preview/PreviewMediaFragment.kt
@@ -103,7 +103,8 @@ class PreviewMediaFragment :
     private var user: User? = null
     private var savedPlaybackPosition: Long = 0
 
-    private var autoplay = true
+    // NMC-5564 fix: deactivate autoplay
+    private var autoplay = false
     private var isLivePhoto = false
     private val prepared = false
 

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -738,6 +738,37 @@ public final class DisplayUtils {
         return df.format(timestamp);
     }
 
+    // NMC Customization: required to hide video icon overlay for albums
+    // will be called from other places except Albums
+    // use to show overlay video icon
+    public static void setThumbnail(OCFile file,
+                                    ImageView thumbnailView,
+                                    User user,
+                                    FileDataStorageManager storageManager,
+                                    List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks,
+                                    boolean gridView,
+                                    Context context,
+                                    LoaderImageView shimmerThumbnail,
+                                    AppPreferences preferences,
+                                    ViewThemeUtils viewThemeUtils,
+                                    OverlayManager overlayManager,
+                                    boolean isMediaGallery
+                                   ) {
+        setThumbnail(file,
+                     thumbnailView,
+                     user,
+                     storageManager,
+                     asyncTasks,
+                     gridView,
+                     context,
+                     shimmerThumbnail,
+                     preferences,
+                     viewThemeUtils,
+                     overlayManager,
+                     false,
+                     isMediaGallery);
+    }
+
     /**
      * Sets a thumbnail for a offline file, file or folder with various display options and states.
      * <p>
@@ -778,7 +809,9 @@ public final class DisplayUtils {
                                     LoaderImageView shimmerThumbnail,
                                     AppPreferences preferences,
                                     ViewThemeUtils viewThemeUtils,
-                                    OverlayManager overlayManager) {
+                                    OverlayManager overlayManager,
+                                    boolean hideVideoOverlay,
+                                    boolean isMediaGallery) {
         if (file == null || thumbnailView == null || context == null) {
             return;
         }
@@ -789,25 +822,36 @@ public final class DisplayUtils {
         }
 
         if (file.isFolder()) {
+            // NMC Customization
+            updateThumbnailViewSize(thumbnailView, gridView, context, isMediaGallery, R.dimen.standard_folders_grid_item_size);
+            // reset the padding as this will change for files and we don't this for folders
+            thumbnailView.setPadding(0, 0, 0, 0);
             overlayManager.setFolderThumbnail(file, thumbnailView, shimmerThumbnail);
             return;
         }
 
+        // NMC Customization
+        updateThumbnailViewSize(thumbnailView, gridView, context, isMediaGallery, R.dimen.standard_files_grid_item_size);
+
         if (file.getRemoteId() == null || !file.isPreviewAvailable()) {
-            setThumbnailFirstTimeForFile(file, thumbnailView, storageManager, asyncTasks, gridView, shimmerThumbnail, user, preferences, context, viewThemeUtils);
+            setThumbnailFirstTimeForFile(file, thumbnailView, storageManager, asyncTasks, gridView, shimmerThumbnail, user, preferences, context, viewThemeUtils, hideVideoOverlay, isMediaGallery);
             return;
         }
 
-        setThumbnailFromCache(file, thumbnailView, storageManager, asyncTasks, gridView, shimmerThumbnail, user, preferences, context, viewThemeUtils);
+        setThumbnailFromCache(file, thumbnailView, storageManager, asyncTasks, gridView, shimmerThumbnail, user, preferences, context, viewThemeUtils, hideVideoOverlay, isMediaGallery);
     }
 
-    private static void setThumbnailFirstTimeForFile(OCFile file, ImageView thumbnailView, FileDataStorageManager storageManager, List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks, boolean gridView, LoaderImageView shimmerThumbnail, User user, AppPreferences preferences, Context context, ViewThemeUtils viewThemeUtils) {
+    private static void setThumbnailFirstTimeForFile(OCFile file, ImageView thumbnailView, FileDataStorageManager storageManager, List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks, boolean gridView, LoaderImageView shimmerThumbnail, User user, AppPreferences preferences, Context context, ViewThemeUtils viewThemeUtils, boolean hideVideoOverlay, boolean isMediaGallery) {
         if (file.getRemoteId() != null) {
-            generateNewThumbnail(file, thumbnailView, user, storageManager, new ArrayList<>(asyncTasks), gridView, context, shimmerThumbnail, preferences, viewThemeUtils);
+            generateNewThumbnail(file, thumbnailView, user, storageManager, new ArrayList<>(asyncTasks), gridView, context, shimmerThumbnail, preferences, viewThemeUtils, hideVideoOverlay, isMediaGallery);
             return;
         }
 
         stopShimmer(shimmerThumbnail, thumbnailView);
+
+        // NMC Customization
+        setThumbnailViewPadding(thumbnailView, gridView, context, isMediaGallery, R.dimen.standard_quarter_padding);
+
         final var icon = MimeTypeUtil.getFileTypeIcon(file.getMimeType(), file.getFileName(), context, viewThemeUtils);
         thumbnailView.setImageDrawable(icon);
     }
@@ -834,22 +878,24 @@ public final class DisplayUtils {
         }
     }
 
-    public static void setThumbnailFromCache(OCFile file, ImageView thumbnailView, FileDataStorageManager storageManager, List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks, boolean gridView, LoaderImageView shimmerThumbnail, User user, AppPreferences preferences, Context context, ViewThemeUtils viewThemeUtils) {
-        final var thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.getRemoteId());
+    public static void setThumbnailFromCache(OCFile file, ImageView thumbnailView, FileDataStorageManager storageManager, List<ThumbnailsCacheManager.ThumbnailGenerationTask> asyncTasks, boolean gridView, LoaderImageView shimmerThumbnail, User user, AppPreferences preferences, Context context, ViewThemeUtils viewThemeUtils, boolean hideVideoOverlay, boolean isMediaGallery) {
+        var thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(ThumbnailsCacheManager.PREFIX_THUMBNAIL + file.getRemoteId());
         if (thumbnail == null || file.isUpdateThumbnailNeeded()) {
-            generateNewThumbnail(file, thumbnailView, user, storageManager, new ArrayList<>(asyncTasks), gridView, context, shimmerThumbnail, preferences, viewThemeUtils);
+            generateNewThumbnail(file, thumbnailView, user, storageManager, new ArrayList<>(asyncTasks), gridView, context, shimmerThumbnail, preferences, viewThemeUtils, hideVideoOverlay, isMediaGallery);
             setThumbnailBackgroundForPNGFileIfNeeded(file, context, thumbnailView);
             return;
         }
 
+        // NMC Customization
+        setThumbnailViewPadding(thumbnailView, gridView, context, isMediaGallery, R.dimen.alternate_padding);
+
         stopShimmer(shimmerThumbnail, thumbnailView);
 
-        if (MimeTypeUtil.isVideo(file)) {
-            final var withOverlay = ThumbnailsCacheManager.addVideoOverlay(thumbnail, context);
-            thumbnailView.setImageBitmap(withOverlay);
-        } else {
-            BitmapUtils.setRoundedBitmapAccordingToListType(gridView, thumbnail, thumbnailView);
+        if (MimeTypeUtil.isVideo(file) && !hideVideoOverlay) {
+            thumbnail = ThumbnailsCacheManager.addVideoOverlay(thumbnail, context);
         }
+        // NMC: set the corner for both video and image thumbnail
+        BitmapUtils.setRoundedBitmapAccordingToListType(gridView, thumbnail, thumbnailView);
 
         setThumbnailBackgroundForPNGFileIfNeeded(file, context, thumbnailView);
     }
@@ -870,7 +916,9 @@ public final class DisplayUtils {
                                              Context context,
                                              LoaderImageView shimmerThumbnail,
                                              AppPreferences preferences,
-                                             ViewThemeUtils viewThemeUtils) {
+                                             ViewThemeUtils viewThemeUtils,
+                                             boolean hideVideoOverlay,
+                                             boolean isMediaGallery) {
         if (!ThumbnailsCacheManager.cancelPotentialThumbnailWork(file, thumbnailView)) {
             return;
         }
@@ -880,7 +928,8 @@ public final class DisplayUtils {
 
         if (thumbnail != null) {
             // If thumbnail is already in cache, display it immediately
-            thumbnailView.setImageBitmap(thumbnail);
+            // NMC: set the corner for both video and image thumbnail
+            BitmapUtils.setRoundedBitmapAccordingToListType(gridView, thumbnail, thumbnailView);
             stopShimmer(shimmerThumbnail, thumbnailView);
             return;
         }
@@ -901,7 +950,8 @@ public final class DisplayUtils {
                                                                    user,
                                                                    asyncTasks,
                                                                    gridView,
-                                                                   file.getRemoteId());
+                                                                   file.getRemoteId(),
+                                                                   hideVideoOverlay);
             Drawable drawable = MimeTypeUtil.getFileTypeIcon(file.getMimeType(),
                                                              file.getFileName(),
                                                              context,
@@ -917,6 +967,10 @@ public final class DisplayUtils {
 
             int px = ThumbnailsCacheManager.getThumbnailDimension();
             thumbnail = BitmapUtils.drawableToBitmap(drawable, px, px);
+
+            //NMC: set thumbnailView padding for no thumbnail
+            setThumbnailViewPadding(thumbnailView, gridView, context, isMediaGallery, R.dimen.standard_quarter_padding);
+
             final ThumbnailsCacheManager.AsyncThumbnailDrawable asyncDrawable =
                 new ThumbnailsCacheManager.AsyncThumbnailDrawable(context.getResources(),
                                                                   thumbnail, task);
@@ -924,9 +978,6 @@ public final class DisplayUtils {
             if (shimmerThumbnail != null) {
                 shimmerThumbnail.postDelayed(() -> {
                     if (thumbnailView.getDrawable() == null) {
-                        if (gridView) {
-                            configShimmerGridImageSize(shimmerThumbnail, preferences.getGridColumns());
-                        }
                         startShimmer(shimmerThumbnail, thumbnailView);
                     }
                 }, 100);
@@ -1001,6 +1052,43 @@ public final class DisplayUtils {
             return displaySize;
         } else {
             throw new Exception("WindowManager not found");
+        }
+    }
+
+    /**
+     * method to set the padding to thumbnail view this is required for files so that there will be space between file
+     * and file name
+     *
+     * @param thumbnailView
+     * @param gridView
+     * @param context
+     * @param isMediaGallery
+     * @param dimensPadding
+     */
+    private static void setThumbnailViewPadding(ImageView thumbnailView, boolean gridView, Context context,
+                                                boolean isMediaGallery, int dimensPadding) {
+        if (gridView && !isMediaGallery) {
+            int padding = context.getResources().getDimensionPixelSize(dimensPadding);
+            thumbnailView.setPadding(0, 0, 0, padding);
+        }
+    }
+
+    /**
+     * method to set manual thumbnail view height and width for folders and files because we are using different size
+     * for both files and folders
+     *
+     * @param thumbnailView
+     * @param gridView
+     * @param context
+     * @param isMediaGallery
+     * @param size
+     */
+    private static void updateThumbnailViewSize(ImageView thumbnailView, boolean gridView, Context context,
+                                                boolean isMediaGallery, int size) {
+        if (gridView && !isMediaGallery) {
+            thumbnailView.getLayoutParams().width =
+                context.getResources().getDimensionPixelSize(size);
+            thumbnailView.getLayoutParams().height = context.getResources().getDimensionPixelSize(size);
         }
     }
 }

--- a/app/src/main/res/drawable/cursor_drawable.xml
+++ b/app/src/main/res/drawable/cursor_drawable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/text_color" />
+    <size android:width="1.5dp" />
+</shape>

--- a/app/src/main/res/layout/activity_edit_image.xml
+++ b/app/src/main/res/layout/activity_edit_image.xml
@@ -14,15 +14,10 @@
     android:background="@color/black"
     tools:ignore="Overdraw">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/black"
-        android:elevation="4dp"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="@style/Theme.ownCloud.Toolbar.AppWidgetContainer"
-        app:layout_constraintTop_toTopOf="parent" />
+    <!-- NMC Customization -->
+    <include
+        layout="@layout/toolbar_standard"
+        android:theme="@style/Theme.ownCloud.Toolbar.AppWidgetContainer" />
 
     <com.canhub.cropper.CropImageView
         android:id="@+id/cropImageView"
@@ -32,7 +27,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@+id/appbar" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/backup_fragment.xml
+++ b/app/src/main/res/layout/backup_fragment.xml
@@ -53,7 +53,6 @@
                 android:id="@+id/backup_settings_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="@dimen/standard_quarter_padding"
                 android:text="@string/backup_settings"
                 android:textStyle="bold" />
 
@@ -82,7 +81,7 @@
                         android:layout_height="wrap_content"
                         android:text="@string/daily_backup"
                         android:textColor="@color/text_color"
-                        android:textSize="@dimen/two_line_primary_text_size" />
+                        android:textSize="14sp" />
 
                     <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/last_backup_with_date"
@@ -100,15 +99,20 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:layout_marginLeft="@dimen/alternate_half_margin"
             android:layout_marginTop="@dimen/standard_margin"
-            android:gravity="end"
+            android:layout_marginRight="@dimen/alternate_half_margin"
+            android:layout_marginBottom="@dimen/standard_margin"
             android:orientation="horizontal">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/contacts_datepicker"
-                style="@style/Widget.Material3.Button.OutlinedButton"
-                android:layout_width="@dimen/backup_button_width"
+                style="@style/OutlinedButton"
+                android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_marginStart="@dimen/alternate_half_margin"
+                android:layout_marginEnd="@dimen/alternate_half_margin"
+                android:layout_weight="0.8"
                 android:minHeight="@dimen/minimum_size_for_touchable_area"
                 android:text="@string/restore_backup"
                 android:visibility="invisible"
@@ -116,9 +120,11 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/backup_now"
-                android:layout_width="@dimen/backup_button_width"
+                android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/standard_half_margin"
+                android:layout_marginStart="@dimen/alternate_half_margin"
+                android:layout_marginEnd="@dimen/alternate_half_margin"
+                android:layout_weight="1"
                 android:minHeight="@dimen/minimum_size_for_touchable_area"
                 android:text="@string/contacts_backup_button"
                 android:theme="@style/Widget.Material3.Button.IconButton.Filled" />

--- a/app/src/main/res/layout/file_thumbnail.xml
+++ b/app/src/main/res/layout/file_thumbnail.xml
@@ -24,7 +24,7 @@
             android:layout_width="@dimen/file_icon_size"
             android:layout_height="@dimen/file_icon_size"
             android:contentDescription="@null"
-            android:src="@drawable/folder" />
+            tools:src="@drawable/folder" />
 
         <ImageView
             android:id="@+id/videoOverlay"

--- a/app/src/main/res/layout/files_folder_picker.xml
+++ b/app/src/main/res/layout/files_folder_picker.xml
@@ -31,8 +31,8 @@
 
         <View
             android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/list_divider_background" />
+            android:layout_height="0.5dp"
+            android:background="@color/divider_color" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/grid_item.xml
+++ b/app/src/main/res/layout/grid_item.xml
@@ -16,29 +16,52 @@
     android:layout_height="@dimen/grid_container_height"
     android:layout_margin="@dimen/grid_container_margin">
 
-    <com.elyeproj.loaderviewlibrary.LoaderImageView
-        android:id="@+id/thumbnail_shimmer"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/gridItemGuideline"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.22" />
+
+    <com.elyeproj.loaderviewlibrary.LoaderImageView
+        android:id="@+id/thumbnail_shimmer"
+        android:layout_width="@dimen/standard_folders_grid_item_size"
+        android:layout_height="@dimen/standard_folders_grid_item_size"
         android:contentDescription="@null"
         android:src="@drawable/folder"
         android:visibility="gone"
+        app:corners="8"
         app:layout_constraintBottom_toBottomOf="@id/thumbnail"
         app:layout_constraintEnd_toEndOf="@id/thumbnail"
         app:layout_constraintStart_toStartOf="@id/thumbnail"
         app:layout_constraintTop_toTopOf="@id/thumbnail"
         tools:visibility="visible" />
 
+
     <com.owncloud.android.ui.SquareImageView
         android:id="@+id/thumbnail"
-        android:layout_width="@dimen/standard_list_item_size"
-        android:layout_height="@dimen/standard_list_item_size"
+        android:layout_width="@dimen/standard_folders_grid_item_size"
+        android:layout_height="@dimen/standard_folders_grid_item_size"
         android:layout_marginTop="@dimen/standard_half_margin"
         android:contentDescription="@null"
         android:src="@drawable/folder"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
+
+    <ImageView
+        android:id="@+id/videoOverlay"
+        android:layout_width="@dimen/grid_layout_item_size"
+        android:layout_height="@dimen/grid_layout_item_size"
+        android:contentDescription="@string/video_overlay_icon"
+        android:src="@drawable/video_white"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/thumbnail"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/grid_file_features_icon_color"
         tools:visibility="visible" />
 
     <LinearLayout
@@ -52,32 +75,14 @@
         android:orientation="horizontal"
         android:padding="@dimen/standard_quarter_padding"
         android:translationZ="4dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/thumbnail"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.85"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.85">
-
-        <ImageView
-            android:id="@+id/favorite_action"
-            android:layout_width="@dimen/grid_layout_item_size"
-            android:layout_height="@dimen/grid_layout_item_size"
-            android:layout_marginEnd="@dimen/grid_layout_margin_end"
-            android:contentDescription="@string/favorite_icon"
-            android:src="@drawable/favorite"
-            tools:visibility="visible" />
-
-        <ImageView
-            android:id="@+id/videoOverlay"
-            android:layout_width="@dimen/grid_layout_item_size"
-            android:layout_height="@dimen/grid_layout_item_size"
-            android:layout_marginEnd="@dimen/grid_layout_margin_end"
-            android:contentDescription="@string/video_overlay_icon"
-            android:src="@drawable/video_white"
-            android:visibility="gone"
-            app:tint="@color/grid_file_features_icon_color"
-            tools:visibility="visible" />
+        app:layout_constraintVertical_bias="0.85"
+        tools:visibility="visible">
 
         <ImageView
             android:id="@+id/sharedIcon"
@@ -86,7 +91,7 @@
             android:layout_marginEnd="@dimen/grid_layout_margin_end"
             android:contentDescription="@string/shared_icon_shared_via_link"
             android:src="@drawable/shared_via_link"
-            app:tint="@color/grid_file_features_icon_color"
+            app:tint="@color/list_icon_color"
             tools:visibility="visible" />
 
         <ImageView
@@ -99,7 +104,7 @@
             android:focusable="true"
             android:src="@drawable/ic_comment_grid"
             android:visibility="gone"
-            app:tint="@color/grid_file_features_icon_color"
+            app:tint="@color/list_icon_color"
             tools:ignore="TouchTargetSizeCheck"
             tools:visibility="visible" />
 
@@ -117,22 +122,34 @@
             tools:ignore="TouchTargetSizeCheck"
             tools:visibility="visible" />
 
-        <ImageView
-            android:id="@+id/localFileIndicator"
-            android:layout_width="@dimen/grid_layout_item_size"
-            android:layout_height="@dimen/grid_layout_item_size"
-            android:layout_marginEnd="@dimen/grid_layout_margin_end"
-            android:contentDescription="@string/synced_icon"
-            android:src="@drawable/ic_synced"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
     </LinearLayout>
 
     <ImageView
+        android:id="@+id/localFileIndicator"
+        android:layout_width="@dimen/list_item_icons_size"
+        android:layout_height="@dimen/list_item_icons_size"
+        app:layout_constraintBottom_toTopOf="@+id/Filename"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginEnd="@dimen/grid_layout_margin_end"
+        android:layout_marginBottom="@dimen/grid_layout_margin_end"
+        android:contentDescription="@string/synced_icon"
+        android:src="@drawable/ic_synced"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <ImageView
+        android:id="@+id/favorite_action"
+        android:layout_width="@dimen/grid_item_icons_size"
+        android:layout_height="@dimen/grid_item_icons_size"
+        android:contentDescription="@string/favorite_icon"
+        android:src="@drawable/favorite"
+        app:layout_constraintBottom_toTopOf="@+id/gridItemGuideline"
+        app:layout_constraintEnd_toEndOf="@+id/thumbnail" />
+
+    <ImageView
         android:id="@+id/custom_checkbox"
-        android:layout_width="@dimen/grid_checkbox_size"
-        android:layout_height="@dimen/grid_checkbox_size"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/grid_checkbox_margin"
         android:layout_marginTop="@dimen/grid_checkbox_margin"
         android:contentDescription="@string/checkbox"
@@ -142,35 +159,36 @@
         tools:visibility="visible" />
 
     <LinearLayout
-        tools:visibility="visible"
         android:id="@+id/bidi_filename_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/grid_bottom_view_height"
-        android:visibility="gone"
         android:gravity="center"
         android:orientation="horizontal"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/thumbnail">
+        app:layout_constraintTop_toBottomOf="@+id/thumbnail"
+        tools:visibility="visible">
 
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_weight="1"
-            android:layout_marginStart="@dimen/iconized_single_line_item_icon_size"
+            android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:gravity="center"
-            android:layout_height="match_parent">
+            android:layout_marginStart="@dimen/iconized_single_line_item_icon_size"
+            android:layout_weight="1"
+            android:gravity="center">
 
             <TextView
                 android:id="@+id/bidi_filename"
                 android:layout_width="wrap_content"
-                android:maxWidth="@dimen/grid_container_default_max_file_name"
                 android:layout_height="match_parent"
                 android:ellipsize="end"
                 android:gravity="center"
+                android:maxWidth="@dimen/grid_container_default_max_file_name"
                 android:maxLines="1"
                 android:text="@string/placeholder_filename"
+                android:textColor="@color/text_color"
                 android:textSize="@dimen/grid_item_text_size" />
 
             <TextView
@@ -181,6 +199,7 @@
                 android:gravity="center"
                 android:maxLines="1"
                 android:text="@string/placeholder_extension"
+                android:textColor="@color/text_color"
                 android:textSize="@dimen/grid_item_text_size" />
 
         </LinearLayout>
@@ -193,6 +212,7 @@
             android:contentDescription="@string/overflow_menu"
             android:translationZ="2dp"
             app:srcCompat="@drawable/ic_dots_vertical"
+            app:tint="@color/list_icon_color"
             tools:ignore="TouchTargetSizeCheck" />
     </LinearLayout>
 
@@ -206,6 +226,7 @@
         android:gravity="center"
         android:singleLine="true"
         android:text="@string/placeholder_filename"
+        android:textColor="@color/text_color"
         android:textSize="@dimen/grid_item_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -228,6 +249,7 @@
         app:layout_constraintStart_toEndOf="@id/Filename"
         app:layout_constraintTop_toBottomOf="@id/thumbnail"
         app:srcCompat="@drawable/ic_dots_vertical"
+        app:tint="@color/list_icon_color"
         tools:ignore="TouchTargetSizeCheck"
         tools:visibility="visible" />
 

--- a/app/src/main/res/layout/list_item.xml
+++ b/app/src/main/res/layout/list_item.xml
@@ -15,17 +15,17 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/ListItemLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="@dimen/standard_list_item_size"
     android:baselineAligned="false"
     android:descendantFocusability="blocksDescendants"
-    android:minHeight="@dimen/min_list_item_size"
     android:orientation="horizontal">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="@dimen/min_list_item_size"
-        android:layout_height="@dimen/min_list_item_size"
+        android:layout_width="@dimen/standard_list_item_size"
+        android:layout_height="@dimen/standard_list_item_size"
         android:layout_marginStart="@dimen/zero"
-        android:layout_marginEnd="@dimen/standard_quarter_padding">
+        android:layout_marginEnd="@dimen/standard_quarter_padding"
+        android:layout_marginBottom="@dimen/standard_padding">
 
         <FrameLayout
             android:id="@+id/thumbnail_container"
@@ -43,12 +43,11 @@
 
         <ImageView
             android:id="@+id/localFileIndicator"
-            android:layout_width="@dimen/list_item_local_file_indicator_layout_width"
-            android:layout_height="@dimen/list_item_local_file_indicator_layout_height"
+            android:layout_width="@dimen/list_item_icons_size"
+            android:layout_height="@dimen/list_item_icons_size"
             android:contentDescription="@string/downloader_download_succeeded_ticker"
             android:visibility="gone"
             tools:visibility="visible"
-            android:scaleType="fitCenter"
             android:src="@drawable/ic_synced"
             app:layout_constraintBottom_toBottomOf="@+id/thumbnail_container"
             app:layout_constraintEnd_toEndOf="@+id/thumbnail_container"
@@ -57,8 +56,8 @@
 
         <ImageView
             android:id="@+id/favorite_action"
-            android:layout_width="@dimen/list_item_favorite_action_layout_width"
-            android:layout_height="@dimen/list_item_favorite_action_layout_height"
+            android:layout_width="@dimen/list_item_icons_size"
+            android:layout_height="@dimen/list_item_icons_size"
             android:contentDescription="@string/favorite"
             android:src="@drawable/favorite"
             app:layout_constraintBottom_toTopOf="@+id/thumbnail_container"
@@ -70,12 +69,11 @@
 
     <LinearLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_weight="1"
         android:gravity="top"
-        android:minHeight="@dimen/min_list_item_size"
         android:orientation="vertical"
-        android:paddingTop="@dimen/standard_half_padding">
+        android:paddingTop="@dimen/standard_padding">
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -229,7 +227,7 @@
 
     <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:gravity="center_vertical|end"
         android:orientation="horizontal"
         android:paddingStart="@dimen/standard_half_padding"
@@ -246,17 +244,17 @@
             android:paddingEnd="@dimen/list_item_share_right_margin"
             android:src="@drawable/ic_comment"
             android:visibility="gone"
-            tools:visibility="visible" />
+            tools:visibility="visible"
+            app:tint="@color/list_icon_color" />
 
         <ImageView
             android:id="@+id/sharedIcon"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
             android:clickable="true"
             android:contentDescription="@string/shared_icon_share"
             android:focusable="true"
-            android:minHeight="@dimen/min_list_item_size"
             android:paddingStart="@dimen/list_item_share_right_margin"
             android:paddingEnd="4dp"
             android:src="@drawable/ic_unshared"
@@ -274,12 +272,11 @@
         <ImageView
             android:id="@+id/custom_checkbox"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
             android:clickable="false"
             android:contentDescription="@string/checkbox"
             android:focusable="false"
-            android:minHeight="@dimen/min_list_item_size"
             android:paddingStart="@dimen/standard_half_padding"
             android:paddingEnd="@dimen/alternate_padding"
             android:src="@drawable/ic_checkbox_blank_outline" />
@@ -287,15 +284,15 @@
         <ImageView
             android:id="@+id/overflow_menu"
             android:layout_width="48dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="top"
+            android:layout_height="match_parent"
+            android:layout_gravity="center_vertical"
             android:clickable="true"
             android:contentDescription="@string/overflow_menu"
             android:focusable="true"
-            android:minHeight="@dimen/min_list_item_size"
             android:paddingStart="@dimen/list_item_share_right_margin"
             android:paddingEnd="@dimen/list_item_share_right_margin"
-            android:src="@drawable/ic_dots_vertical" />
+            android:src="@drawable/ic_dots_vertical"
+            app:tint="@color/list_icon_color" />
 
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/receive_external_files.xml
+++ b/app/src/main/res/layout/receive_external_files.xml
@@ -12,6 +12,7 @@
     android:id="@+id/upload_files_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/bg_default"
     android:orientation="vertical">
 
     <include

--- a/app/src/main/res/layout/synced_folders_settings_layout.xml
+++ b/app/src/main/res/layout/synced_folders_settings_layout.xml
@@ -11,6 +11,7 @@
     android:id="@+id/root"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:background="@color/bg_default"
     android:gravity="center"
     android:orientation="vertical">
 
@@ -219,6 +220,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:ellipsize="marquee"
+                        android:maxLines="2"
                         android:text="@string/instant_upload_existing"
                         android:textAppearance="?attr/textAppearanceListItem" />
                 </RelativeLayout>

--- a/app/src/main/res/layout/trashbin_item.xml
+++ b/app/src/main/res/layout/trashbin_item.xml
@@ -6,6 +6,7 @@
   ~ SPDX-License-Identifier: AGPL-3.0-or-later OR GPL-2.0-only
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/ListItemLayout"
     android:layout_width="match_parent"
@@ -108,7 +109,8 @@
                 android:focusable="false"
                 android:paddingEnd="@dimen/list_item_share_right_margin"
                 android:paddingStart="@dimen/standard_half_padding"
-                android:src="@drawable/ic_history"/>
+                android:src="@drawable/ic_history"
+                app:tint="@color/list_icon_color"/>
 
             <ImageView
                 android:id="@+id/customCheckbox"
@@ -134,7 +136,8 @@
                 android:focusable="true"
                 android:paddingEnd="@dimen/alternate_padding"
                 android:paddingStart="@dimen/standard_half_padding"
-                android:src="@drawable/ic_dots_vertical"/>
+                android:src="@drawable/ic_dots_vertical"
+                app:tint="@color/list_icon_color"/>
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/upload_files_layout.xml
+++ b/app/src/main/res/layout/upload_files_layout.xml
@@ -26,17 +26,10 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
-    <LinearLayout
+    <View
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/list_divider_background"/>
-
-    </LinearLayout>
+        android:layout_height="0.5dp"
+        android:background="@color/divider_color" />
 
     <LinearLayout
         android:id="@+id/upload_options"

--- a/app/src/main/res/layout/upload_list_header.xml
+++ b/app/src/main/res/layout/upload_list_header.xml
@@ -33,7 +33,8 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:contentDescription="@string/upload_list_expand_header"
-            android:src="@drawable/ic_expand_less" />
+            android:src="@drawable/ic_expand_less"
+            app:tint="@color/list_icon_color"/>
     </FrameLayout>
 
     <TextView
@@ -60,6 +61,6 @@
         android:paddingTop="@dimen/standard_half_padding"
         android:paddingEnd="@dimen/zero"
         android:paddingBottom="@dimen/standard_half_padding"
-        android:src="@drawable/ic_delete"
-        app:tint="#757575" />
+        android:src="@drawable/nav_trashbin"
+        app:tint="@color/list_icon_color" />
 </RelativeLayout>

--- a/app/src/main/res/layout/upload_list_item.xml
+++ b/app/src/main/res/layout/upload_list_item.xml
@@ -9,6 +9,7 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/upload_list_item_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -124,6 +125,7 @@
         android:background="@android:color/transparent"
         android:contentDescription="@string/upload_item_action_button"
         android:paddingStart="@dimen/standard_double_padding"
-        android:paddingEnd="@dimen/zero" />
+        android:paddingEnd="@dimen/zero"
+        app:tint="@color/list_icon_color"/>
 
 </LinearLayout>

--- a/app/src/main/res/menu/activity_upload_list.xml
+++ b/app/src/main/res/menu/activity_upload_list.xml
@@ -12,10 +12,12 @@
         android:id="@+id/upload_list_actions"
         android:checkableBehavior="none">
 
+        <!-- NMC-5316: hide global upload pause -->
         <item
             android:id="@+id/action_toggle_global_pause"
             android:icon="@drawable/ic_global_pause"
             android:title="@string/upload_action_global_upload_pause"
+            android:visible="false"
             app:showAsAction="always" />
     </group>
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1202,6 +1202,7 @@
     <string name="version_dev_download">Herunterladen</string>
     <string name="video_overlay_icon">Video Überlagerungsicon</string>
     <string name="wait_a_moment">Bitte warten …</string>
+    <string name="camera_permission_rationale">Bitte geben Sie unter Apps &amp; Benachrichtigungen in den Einstellungen manuell die Erlaubnis.</string>
     <string name="wait_checking_credentials">Überprüfe gespeicherte Anmeldeinformationen</string>
     <string name="wait_for_tmp_copy_from_private_storage">Kopiere Datei von privatem Speicher</string>
     <string name="warn_rename_extension">Das Ändern der Erweiterung kann dazu führen, dass diese Datei in einer anderen Anwendung geöffnet wird</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -7,6 +7,7 @@
 -->
 <resources>
 
+    <color name="list_item_lastmod_and_filesize_text">@color/grey_30</color>
     <color name="text_color">#E3E3E3</color>
     <color name="text_color_inverse">#000000</color>
     <color name="disabled_text">#ff6F6F6F</color>
@@ -25,7 +26,7 @@
 
     <!-- Multiselect backgrounds -->
     <color name="action_mode_background">@color/appbar</color>
-    <color name="selected_item_background">#373535</color>
+    <color name="selected_item_background">@color/grey_70</color>
 
     <color name="filelist_icon_background">#222222</color>
     <color name="standard_grey">#DADADA</color>
@@ -35,8 +36,73 @@
     <color name="drawer_active_item_background">@color/white</color>
 
     <!-- App bar -->
-    <color name="appbar">#1E1E1E</color>
+    <color name="appbar">#121212</color>
     <color name="fontAppbar">@android:color/white</color>
 
     <color name="bg_message_bubble">#2A2A2A</color>
+
+    <!-- NMC Colors -->
+    <color name="icon_color">#FFFFFF</color>
+    <color name="sort_text_color">@color/grey_30</color>
+    <color name="list_icon_color">@color/grey_30</color>
+    <color name="warning_icon_color">#CCCCCC</color>
+    <color name="divider_color">@color/grey_70</color>
+    <color name="spinner_bg_color">@color/grey_80</color>
+    <color name="refresh_layout_bg_color">#2D2D2D</color>
+    <color name="primary_button_disabled_color">@color/grey_70</color>
+    <color name="toolbar_divider_color">@color/grey_70</color>
+
+    <!-- Snackbar Colors -->
+    <color name="snackbar_bg_color">@color/grey_80</color>
+    <color name="snackbar_txt_color">@color/grey_0</color>
+
+    <!-- Alert Dialog Colors -->
+    <color name="alert_bg_color">@color/grey_80</color>
+    <color name="alert_txt_color">@color/grey_0</color>
+
+    <!--  NavigationView colors  -->
+    <color name="nav_selected_bg_color">@color/grey_60</color>
+    <color name="nav_txt_unselected_color">@color/grey_0</color>
+    <color name="nav_txt_selected_color">@color/grey_0</color>
+    <color name="nav_icon_unselected_color">@color/grey_30</color>
+    <color name="nav_icon_selected_color">#FFFFFF</color>
+    <color name="nav_divider_color">@color/grey_30</color>
+    <color name="nav_bg_color">@color/grey_80</color>
+    <color name="drawer_quota_txt_color">#FFFFFF</color>
+
+    <!-- Bottom Sheet Colors -->
+    <color name="bottom_sheet_bg_color">@color/grey_80</color>
+    <color name="bottom_sheet_icon_color">@color/grey_30</color>
+    <color name="bottom_sheet_txt_color">@color/grey_0</color>
+
+    <!-- Popup Menu Colors -->
+    <color name="popup_menu_bg">@color/grey_80</color>
+    <color name="popup_menu_txt_color">@color/grey_0</color>
+    <color name="overflow_bg_color">@color/grey_80</color>
+
+    <!-- Switch Compat Colors -->
+    <color name="switch_thumb_disabled">@color/grey_70</color>
+    <color name="switch_track_disabled">@color/grey_60</color>
+
+    <!-- Checkbox Colors -->
+    <color name="checkbox_checked_disabled">@color/grey_70</color>
+    <color name="checkbox_unchecked_disabled">@color/grey_70</color>
+
+    <!-- Share Colors -->
+    <color name="share_title_txt_color">#FFFFFF</color>
+    <color name="share_subtitle_txt_color">@color/grey_30</color>
+    <color name="share_info_txt_color">@color/grey_0</color>
+    <color name="share_search_border_color">@color/grey_0</color>
+    <color name="share_btn_txt_color">@color/grey_0</color>
+    <color name="share_list_item_txt_color">@color/grey_0</color>
+    <color name="share_disabled_txt_color">@color/grey_60</color>
+    <color name="share_txt_color">@color/grey_0</color>
+    <color name="share_et_divider">#FFFFFF</color>
+    <color name="share_blue_color">#7d94f9</color>
+
+    <!-- Scan Colors -->
+    <color name="scan_doc_bg_color">#121212</color>
+    <color name="scan_text_color">@color/grey_0</color>
+    <color name="scan_edit_bottom_color">@color/grey_80</color>
+    <color name="scan_count_bg_color">@color/grey_80</color>
 </resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -23,5 +23,8 @@
         <item name="popupMenuStyle">@style/Nextcloud.Widget.PopupMenu</item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
         <item name="actionModeStyle">@style/App.ActionMode</item>
+        <!-- styling autocomplete text view mainly for search view cursor color-->
+        <item name="autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
+        <item name="android:autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
     </style>
 </resources>

--- a/app/src/main/res/values-sw600dp/dims.xml
+++ b/app/src/main/res/values-sw600dp/dims.xml
@@ -8,5 +8,7 @@
 -->
 <resources>
   <integer name="media_grid_width">6</integer>
+    <dimen name="file_icon_rounded_corner_radius">32dp</dimen>
+    <dimen name="file_icon_rounded_corner_radius_for_grid_mode">16dp</dimen>
     <dimen name="file_icon_size_grid">512dp</dimen>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,11 +10,12 @@
   ~ SPDX-License-Identifier: GPL-2.0-only AND (AGPL-3.0-or-later OR GPL-2.0-only)
 -->
 <resources>
-    <color name="list_item_lastmod_and_filesize_text">@color/secondary_text_color</color>
+    <color name="list_item_lastmod_and_filesize_text">@color/grey_600</color>
     <color name="black">#000000</color>
     <color name="white">#ffffff</color>
     <color name="white_helper_text">#B3FFFFFF</color>
-    <color name="text_color">#333333</color>
+    <color name="text_color">#191919</color>
+    <color name="light_grey">#F5F5F5</color>
     <color name="grid_file_features_icon_color">#303034</color>
     <color name="grid_file_features_background_color">#E9E8EB</color>
     <color name="drawer_text_color">@color/secondary_text_color</color>
@@ -24,7 +25,7 @@
     <color name="fg_inverse">#FFFFFF</color>
     <color name="filelist_icon_background">#DDDDDD</color>
     <color name="transparent">#00000000</color>
-    <color name="secondary_text_color">#666666</color>
+    <color name="secondary_text_color">@color/grey_30</color>
     <color name="highlight_textColor_Warning">#e53935</color>
 
     <!-- Colors -->
@@ -75,17 +76,107 @@
     <color name="color_dark_transparent">#40162233</color>
 
     <!-- Multiselect backgrounds -->
-    <color name="action_mode_background">@color/fontAppbar</color>
-    <color name="selected_item_background">#ECECEC</color>
+    <color name="action_mode_background">@color/white</color>
+    <color name="selected_item_background">@color/grey_0</color>
 
     <color name="drawer_menu_icon">#757575</color>
     <color name="bg_fallback_highlight">#616161</color>
-    <color name="drawer_active_item_background">#80000000</color>
+    <color name="drawer_active_item_background">#919191</color>
 
     <!-- App bar -->
     <color name="appbar">@android:color/white</color>
-    <color name="fontAppbar">#666666</color>
+    <color name="fontAppbar">#191919</color>
     <color name="fontSecondaryAppbar">#A5A5A5</color>
 
     <color name="bg_message_bubble">#EFEFEF</color>
+
+    <!--  NMC Colors  -->
+    <color name="icon_color">#191919</color>
+    <color name="sort_text_color">@color/primary</color>
+    <color name="list_icon_color">#191919</color>
+    <color name="warning_icon_color">#191919</color>
+    <color name="divider_color">@color/grey_30</color>
+    <color name="spinner_bg_color">@android:color/white</color>
+    <color name="refresh_layout_bg_color">#FFFFFF</color>
+    <color name="primary_button_disabled_color">@color/grey_0</color>
+    <color name="toolbar_divider_color">#CCCCCC</color>
+    <color name="et_highlight_color">#77c4ff</color>
+    <color name="white_trans_70">#B3FFFFFF</color>
+    <color name="progress_bar_background">@color/grey_10</color>
+
+    <!-- Grey Colors -->
+    <color name="dark_grey">#101010</color>
+    <color name="grey_0">#F2F2F2</color>
+    <color name="grey_10">#E5E5E5</color>
+    <color name="grey_30">#B2B2B2</color>
+    <color name="grey_60">#666666</color>
+    <color name="grey_70">#4C4C4C</color>
+    <color name="grey_80">#333333</color>
+
+    <!-- Snackbar Colors  -->
+    <color name="snackbar_bg_color">@color/design_snackbar_background_color</color>
+    <color name="snackbar_txt_color">@color/white</color>
+
+    <!-- Alert Dialog Colors -->
+    <color name="alert_bg_color">#FFFFFF</color>
+    <color name="alert_txt_color">#191919</color>
+
+    <!--  NavigationView colors  -->
+    <color name="nav_selected_bg_color">@color/grey_0</color>
+    <color name="nav_txt_unselected_color">#191919</color>
+    <color name="nav_txt_selected_color">@color/primary</color>
+    <color name="nav_icon_unselected_color">#191919</color>
+    <color name="nav_icon_selected_color">@color/primary</color>
+    <color name="nav_divider_color">@color/grey_30</color>
+    <color name="nav_bg_color">@color/white</color>
+    <color name="drawer_quota_txt_color">#191919</color>
+
+    <!-- Bottom Sheet Colors -->
+    <color name="bottom_sheet_bg_color">#FFFFFF</color>
+    <color name="bottom_sheet_icon_color">#191919</color>
+    <color name="bottom_sheet_txt_color">#191919</color>
+
+    <!-- Popup Menu Colors -->
+    <color name="popup_menu_bg">#FFFFFF</color>
+    <color name="popup_menu_txt_color">#191919</color>
+    <color name="overflow_bg_color">#FFFFFF</color>
+
+    <!-- Switch Compat Colors -->
+    <color name="switch_thumb_checked_enabled">@color/primary</color>
+    <color name="switch_track_checked_enabled">#F399C7</color>
+    <color name="switch_thumb_unchecked_enabled">#FFFFFF</color>
+    <color name="switch_track_unchecked_enabled">@color/grey_30</color>
+    <color name="switch_thumb_disabled">@color/grey_10</color>
+    <color name="switch_track_disabled">@color/grey_0</color>
+
+    <!-- Checkbox Colors -->
+    <color name="checkbox_checked_enabled">@color/primary</color>
+    <color name="checkbox_unchecked_enabled">@color/grey_30</color>
+    <color name="checkbox_checked_disabled">@color/grey_30</color>
+    <color name="checkbox_unchecked_disabled">#CCCCCC</color>
+
+    <!-- Share Colors -->
+    <color name="share_title_txt_color">#191919</color>
+    <color name="share_subtitle_txt_color">@color/grey_30</color>
+    <color name="share_info_txt_color">#191919</color>
+    <color name="share_search_border_color">#191919</color>
+    <color name="share_btn_txt_color">#191919</color>
+    <color name="share_list_item_txt_color">#191919</color>
+    <color name="share_disabled_txt_color">@color/grey_30</color>
+    <color name="share_txt_color">#191919</color>
+    <color name="share_et_divider">#000000</color>
+    <color name="share_warning_txt_color">#191919</color>
+    <color name="sharing_warning_bg_color">#F6E5EB</color>
+    <color name="sharing_warning_border_color">#C16F81</color>
+    <color name="share_color">#0D39DF</color>
+    <color name="shared_with_me_color">#0099ff</color>
+    <color name="share_blue_color">#2238df</color>
+
+    <!--  Scan Colors  -->
+    <color name="scan_doc_bg_color">@color/grey_0</color>
+    <color name="scan_text_color">#191919</color>
+    <color name="scan_edit_bottom_color">@color/grey_0</color>
+    <color name="scan_count_bg_color">@color/grey_30</color>
+    <color name="neptune">#77b6bb</color>
+    <color name="neptune_50">#5077b6bb</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="grid_recyclerview_padding">4dp</dimen>
+    <dimen name="list_item_icons_size">16dp</dimen>
+    <dimen name="grid_item_icons_size">24dp</dimen>
+    <dimen name="grid_item_shared_icon_layout_top_margin">24dp</dimen>
+    <dimen name="media_grid_item_rv_spacing">6dp</dimen>
+    <dimen name="txt_size_18sp">18sp</dimen>
+    <dimen name="txt_size_15sp">15sp</dimen>
+    <dimen name="crop_corner_size">15dp</dimen>
+    <dimen name="edit_scan_bottom_bar_height">56dp</dimen>
+    <dimen name="standard_folders_grid_item_size">86dp</dimen>
+    <dimen name="standard_files_grid_item_size">80dp</dimen>
+    <dimen name="txt_size_11sp">11sp</dimen>
+    <dimen name="share_row_icon_size">30dp</dimen>
+    <dimen name="create_link_button_height">55dp</dimen>
+    <dimen name="note_et_height">258dp</dimen>
+    <dimen name="txt_size_17sp">17sp</dimen>
+    <dimen name="share_exp_date_divider_margin">20dp</dimen>
+    <dimen name="privacy_btn_width">160dp</dimen>
+    <dimen name="privacy_icon_size">50dp</dimen>
+    <dimen name="login_btn_width">150dp</dimen>
+    <dimen name="login_btn_height">55dp</dimen>
+    <dimen name="login_btn_bottom_margin">48dp</dimen>
+    <dimen name="login_btn_bottom_margin_land">48dp</dimen>
+    <dimen name="login_btn_bottom_margin_small_screen">24dp</dimen>
+    <dimen name="shared_with_me_icon_size">26dp</dimen>
+    <dimen name="txt_size_20sp">20sp</dimen>
+    <dimen name="notification_row_item_height">145dp</dimen>
+    <dimen name="button_stroke_width">1dp</dimen>
+    <dimen name="txt_size_13sp">13sp</dimen>
+</resources>

--- a/app/src/main/res/values/dims.xml
+++ b/app/src/main/res/values/dims.xml
@@ -21,7 +21,7 @@
     <dimen name="live_photo_indicator_margin">100dp</dimen>
     <dimen name="file_icon_size_grid">128dp</dimen>
     <dimen name="file_icon_rounded_corner_radius">8dp</dimen>
-    <dimen name="file_icon_rounded_corner_radius_for_grid_mode">3dp</dimen>
+    <dimen name="file_icon_rounded_corner_radius_for_grid_mode">4dp</dimen>
     <integer name="file_avatar_px">512</integer>
     <dimen name="drawer_content_horizontal_padding">28dp</dimen>
     <dimen name="standard_padding">16dp</dimen>
@@ -87,7 +87,7 @@
     <dimen name="drawer_header_subtext">12sp</dimen>
     <dimen name="fragment_margin">12dp</dimen>
     <dimen name="drawer_width">240dp</dimen>
-    <dimen name="grid_item_text_size">16sp</dimen>
+    <dimen name="grid_item_text_size">14sp</dimen>
     <dimen name="share_file_layout_text_size">12sp</dimen>
     <dimen name="ssl_untrusted_cert_layout_padding">20dp</dimen>
     <dimen name="upload_list_item_frame_layout_width">60dp</dimen>
@@ -115,11 +115,13 @@
     <dimen name="contactlist_item_icon_layout_height">40dp</dimen>
     <dimen name="empty_list_icon_layout_width">72dp</dimen>
     <dimen name="empty_list_icon_layout_height">72dp</dimen>
+    <dimen name="grid_item_local_file_indicator_layout_width">24dp</dimen>
+    <dimen name="grid_item_local_file_indicator_layout_height">24dp</dimen>
     <dimen name="grid_sync_item_layout_counter_text_size">22sp</dimen>
     <dimen name="list_item_favorite_action_layout_width">14dp</dimen>
     <dimen name="list_item_favorite_action_layout_height">14dp</dimen>
-    <dimen name="list_item_local_file_indicator_layout_width">12dp</dimen>
-    <dimen name="list_item_local_file_indicator_layout_height">12dp</dimen>
+    <dimen name="list_item_local_file_indicator_layout_width">24dp</dimen>
+    <dimen name="list_item_local_file_indicator_layout_height">24dp</dimen>
     <dimen name="preview_error_image_layout_width">72dp</dimen>
     <dimen name="preview_error_image_layout_height">72dp</dimen>
     <dimen name="preview_error_text_size">26sp</dimen>

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -58,7 +58,7 @@
     <integer name="contacts_backup_expire">-1</integer>
     <string name="calendar_backup_folder">/.Calendar-Backup</string>
     <!-- flag to enable/disable contact backup -->
-    <bool name="show_calendar_backup">true</bool>
+    <bool name="show_calendar_backup">false</bool>
 
     <!-- What's new -->
     <bool name="show_whats_new">true</bool>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1311,6 +1311,7 @@
     <string name="link_name">Link Name</string>
     <string name="delete_link">Delete Link</string>
     <string name="share_settings">Settings</string>
+    <string name="camera_permission_rationale">Please navigate to App info in settings and give permission manually.</string>
     <string name="common_confirm">Confirm</string>
     <string name="destination_filename">Destination filename</string>
     <string name="suggest">Suggest</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -32,6 +32,9 @@
         <item name="android:navigationBarColor">@color/bg_default</item>
         <item name="textInputStyle">@style/Widget.App.TextInputLayout</item>
         <item name="dialogCornerRadius">@dimen/dialogBorderRadius</item>
+        <!-- styling autocomplete text view mainly for search view cursor color-->
+        <item name="autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
+        <item name="android:autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
     </style>
 
     <style name="Theme.ownCloud" parent="BaseTheme.ownCloud">
@@ -45,6 +48,9 @@
         <item name="android:textColor">@color/text_color</item>
         <item name="android:textColorSecondary">@color/secondary_text_color</item>
         <item name="android:windowBackground">@color/bg_default</item>
+        <item name="colorAccent">@color/color_accent</item>
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorSecondary">@color/secondary_text_color</item>
         <item name="dialogTheme">@style/FallbackTheming.Dialog</item>
         <item name="android:actionModeBackground">@color/action_mode_background</item>
@@ -52,6 +58,9 @@
         <item name="android:navigationBarColor">@color/bg_default</item>
         <item name="textInputStyle">@style/Widget.App.TextInputLayout</item>
         <item name="dialogCornerRadius">@dimen/dialogBorderRadius</item>
+        <!-- styling autocomplete text view mainly for search view cursor color-->
+        <item name="autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
+        <item name="android:autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
     </style>
 
     <style name="FallbackThemingTheme" parent="FallbackThemingThemeBase">
@@ -483,6 +492,10 @@
 
     <style name="App.ActionModeTitleText" parent="TextAppearance.Material3.ActionBar.Title">
         <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="AutoCompleteCursorColorStyle" parent="Widget.AppCompat.AutoCompleteTextView">
+        <item name="android:textCursorDrawable">@drawable/cursor_drawable</item>
     </style>
 
     <!-- Splash screen style attributes: https://developer.android.com/develop/ui/views/launch/splash-screen#set-theme -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,6 +24,9 @@
         <item name="popupMenuStyle">@style/Nextcloud.Widget.PopupMenu</item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
         <item name="actionModeStyle">@style/App.ActionMode</item>
+        <!-- styling autocomplete text view mainly for search view cursor color-->
+        <item name="autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
+        <item name="android:autoCompleteTextViewStyle">@style/AutoCompleteCursorColorStyle</item>
     </style>
 
     <style name="Theme.ownCloud.Toolbar.AppWidgetContainerParent" parent="@android:style/Theme.DeviceDefault">

--- a/app/src/test/java/com/nmc/DatabaseVersionTest.kt
+++ b/app/src/test/java/com/nmc/DatabaseVersionTest.kt
@@ -1,0 +1,14 @@
+package com.nmc
+
+import com.nextcloud.client.database.NextcloudDatabase
+import org.junit.Test
+
+class DatabaseVersionTest {
+
+    @Test
+    fun validateDatabaseVersion() {
+        //for NMC the version will start from 64 only
+        //validating via test case to check if any test changes done during rebasing or merging
+        assert(64 == NextcloudDatabase.FIRST_ROOM_DB_VERSION)
+    }
+}


### PR DESCRIPTION
NMC-1920: 
1. Grid and List item ui changed.
2. Snackbar and Autocomplete text view styling. 
3. Minor UI changes.

NMC-2121: Theming customization for app pin (pass code).

NMC-2374: Theming related changes to Image Edit functionality.
Using this functionality the user can rotate and crop the images.

NMC-2127: System default night mode.
NMC-2123: Disabling the widget for MagentaCloud.
NMC-1941: Fix error message after camera permission declined.
NMC-2052: Fix back arrow instead of hamburger in All Files and during navigating between screens.
NMC-2576: Disabled switch account SnackBar

NMC-2465: App is crashing or stuck at launcher screen when user upgrade to latest app.
But for fresh install there won't be any crash.
Example: If user has play store version 7.21.9 and user upgrade to 7.21.18. The app will crash for that user.

NMC-1919: Hiding calendar from configurable flag.
Button size and padding customized.

NMC-2089:  Reduce log level for release build.

NMC-4633: Disable contact & calendar permission check in Search Fragment.

Media View multi-selection customization.

NMC-4799: uploads screen icon color fix

NMC-4862: deactivate github report snackbar

NMC-5316: hide global upload pause icon

NMC-5564 : deactivate autoplay for video in preview

NMC-5368 & NMC-5364 : fallbackDestructive migration for missing db migration