### PR TITLE
Nmc/2125 Upload file behaviour

### DIFF
--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -429,7 +429,8 @@ public final class AppPreferencesImpl implements AppPreferences {
 
     @Override
     public int getUploaderBehaviour() {
-        return preferences.getInt(AUTO_PREF__UPLOADER_BEHAVIOR, 1);
+        //NMC Customization
+        return preferences.getInt(AUTO_PREF__UPLOADER_BEHAVIOR, 0);
     }
 
     @Override

--- a/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/UploadFilesActivity.java
@@ -197,8 +197,9 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
 
         // file upload spinner
         List<String> behaviours = new ArrayList<>();
-        behaviours.add(getString(R.string.uploader_upload_files_behaviour_move_to_nextcloud_folder,
-                                 themeUtils.getDefaultDisplayNameForRootFolder(this)));
+        // Not required this option for NMC
+        // behaviours.add(getString(R.string.uploader_upload_files_behaviour_move_to_nextcloud_folder,
+        //                        themeUtils.getDefaultDisplayNameForRootFolder(this)));
         behaviours.add(getString(R.string.uploader_upload_files_behaviour_only_upload));
         behaviours.add(getString(R.string.uploader_upload_files_behaviour_upload_and_delete_from_source));
 
@@ -207,6 +208,19 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
         behaviourAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         binding.uploadFilesSpinnerBehaviour.setAdapter(behaviourAdapter);
         binding.uploadFilesSpinnerBehaviour.setSelection(localBehaviour);
+        //NMC Customization
+        binding.uploadFilesSpinnerBehaviour.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                // store behaviour
+                preferences.setUploaderBehaviour(binding.uploadFilesSpinnerBehaviour.getSelectedItemPosition());
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
 
         // setup the toolbar
         setupToolbar();
@@ -271,7 +285,12 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
     private void fillDirectoryDropdown() {
         File currentDir = mCurrentDir;
         while (currentDir != null && currentDir.getParentFile() != null) {
-            mDirectories.add(currentDir.getName());
+            //NMC Customization
+            if (currentDir.getName().equals("0")) {
+                mDirectories.add(getResources().getString(R.string.storage_internal_storage));
+            } else {
+                mDirectories.add(currentDir.getName());
+            }
             currentDir = currentDir.getParentFile();
         }
         mDirectories.add(File.separator);
@@ -502,15 +521,16 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
 
                 // set result code
                 switch (binding.uploadFilesSpinnerBehaviour.getSelectedItemPosition()) {
-                    case 0: // move to nextcloud folder
+                    // Not required for NMC
+                    /*case 0: // move to nextcloud folder
                         setResult(RESULT_OK_AND_MOVE, data);
-                        break;
+                        break;*/
 
-                    case 1: // only upload
+                    case 0: // only upload
                         setResult(RESULT_OK_AND_DO_NOTHING, data);
                         break;
 
-                    case 2: // upload and delete from source
+                    case 1: // upload and delete from source
                         setResult(RESULT_OK_AND_DELETE, data);
                         break;
 
@@ -576,7 +596,8 @@ public class UploadFilesActivity extends DrawerActivity implements LocalFileList
             int localBehaviour = preferences.getUploaderBehaviour();
             binding.uploadFilesSpinnerBehaviour.setSelection(localBehaviour);
         } else {
-            binding.uploadFilesSpinnerBehaviour.setSelection(1);
+            //NMC Customization
+            binding.uploadFilesSpinnerBehaviour.setSelection(0);
             textView.setText(new StringBuilder().append(getString(R.string.uploader_upload_files_behaviour))
                                  .append(' ')
                                  .append(getString(R.string.uploader_upload_files_behaviour_not_writable))

--- a/app/src/main/java/com/owncloud/android/ui/dialog/LocalStoragePathPickerDialogFragment.kt
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/LocalStoragePathPickerDialogFragment.kt
@@ -92,12 +92,14 @@ class LocalStoragePathPickerDialogFragment :
                     Environment.getExternalStoragePublicDirectory(standardDirectory.name).absolutePath
                 )
             }
-            val sdCard = getString(R.string.storage_internal_storage)
             for (dir in FileStorageUtils.getStorageDirectories(requireActivity())) {
+                //NMC Customisation
                 if (internalStoragePaths.contains(dir)) {
-                    addIfExists(storagePathItems, R.drawable.ic_sd_grey600, sdCard, dir)
+                    val internalStorage = getString(R.string.storage_internal_storage)
+                    addIfExists(storagePathItems, R.drawable.ic_sd_grey600, internalStorage, dir)
                 } else {
-                    addIfExists(storagePathItems, R.drawable.ic_sd_grey600, File(dir).name, dir)
+                    val sdCard = getString(R.string.storage_sd_card)
+                    addIfExists(storagePathItems, R.drawable.ic_sd, sdCard, dir)
                 }
             }
             return storagePathItems

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1029,6 +1029,7 @@
     <string name="write_email">E-Mail senden</string>
     <string name="wrong_storage_path">Speicherordner existiert nicht!</string>
     <string name="wrong_storage_path_desc">Ursache könnte die Wiederherstellung einer Sicherungskopie auf einem anderen Gerät sein. Der Standard-Ordner wird jetzt wieder verwendet. Bitte überprüfen Sie die Einstellungen bezüglich des Speicherortes.</string>
+    <string name="storage_sd_card">SD-Karte</string>
     <plurals name="sync_fail_in_favourites_content">
         <item quantity="one">Inhalte von %1$d Datei konnten nicht synchronisiert werden (Konflikte: %2$d)</item>
         <item quantity="other">Inhalte von %1$d Dateien konnten nicht synchronisiert werden (Konflikte: %2$d)</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1098,6 +1098,7 @@
     <string name="delete_link">Delete Link</string>
     <string name="share_settings">Settings</string>
     <string name="common_confirm">Confirm</string>
+    <string name="storage_sd_card">SD Card</string>
     <string name="strict_mode">Strict mode: no HTTP connection allowed!</string>
     <string name="destination_filename">Destination filename</string>
     <string name="suggest">Suggest</string>


### PR DESCRIPTION
Upload file behaviour customized.
1. Doesn't require: **uploader_upload_files_behaviour_move_to_nextcloud_folder**
2. For "0" storage path show **Internal storage** string.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
