### PR TITLE
Nmc/2140 Tinting removed for folder and file icons

### DIFF
--- a/app/src/main/java/com/nextcloud/utils/ShortcutUtil.kt
+++ b/app/src/main/java/com/nextcloud/utils/ShortcutUtil.kt
@@ -16,6 +16,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -59,10 +60,13 @@ class ShortcutUtil @Inject constructor(private val mContext: Context) {
                 icon = IconCompat.createWithAdaptiveBitmap(thumbnail)
             } else if (file.isFolder) {
                 val isAutoUploadFolder = SyncedFolderProvider.isAutoUploadFolder(syncedFolderProvider, file, user)
-                val isDarkModeActive = syncedFolderProvider.preferences.isDarkModeEnabled
 
                 val overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder)
-                val drawable = MimeTypeUtil.getFileIcon(isDarkModeActive, overlayIconId, mContext, viewThemeUtils)
+                // NMC Customization: No overlay icon will be used. Directly using folder icons
+                val drawable = ContextCompat.getDrawable(mContext, overlayIconId) ?: MimeTypeUtil.getDefaultFolderIcon(
+                    mContext,
+                    viewThemeUtils
+                )
                 val bitmapIcon = drawable.toBitmap()
                 icon = IconCompat.createWithBitmap(bitmapIcon)
             } else {

--- a/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/EditorWebView.java
@@ -40,6 +40,8 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import androidx.core.content.ContextCompat;
+
 public abstract class EditorWebView extends ExternalSiteWebView {
     public static final int REQUEST_LOCAL_FILE = 101;
     public ValueCallback<Uri[]> uploadMessage;
@@ -235,8 +237,8 @@ public abstract class EditorWebView extends ExternalSiteWebView {
             boolean isAutoUploadFolder = SyncedFolderProvider.isAutoUploadFolder(syncedFolderProvider, file, user);
 
             Integer overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder);
-            LayerDrawable drawable = MimeTypeUtil.getFileIcon(preferences.isDarkModeEnabled(), overlayIconId, this, viewThemeUtils);
-            binding.thumbnail.setImageDrawable(drawable);
+            // NMC Customization: No overlay icon will be used. Directly using folder icons
+            binding.thumbnail.setImageDrawable(ContextCompat.getDrawable(this, overlayIconId));
         } else {
             if ((MimeTypeUtil.isImage(file) || MimeTypeUtil.isVideo(file)) && file.getRemoteId() != null) {
                 // Thumbnail in cache?

--- a/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
+++ b/app/src/main/java/com/owncloud/android/ui/activity/ShareActivity.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -73,8 +74,8 @@ public class ShareActivity extends FileActivity {
             boolean isAutoUploadFolder = SyncedFolderProvider.isAutoUploadFolder(syncedFolderProvider, file, optionalUser.get());
 
             Integer overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder);
-            LayerDrawable drawable = MimeTypeUtil.getFileIcon(preferences.isDarkModeEnabled(), overlayIconId, this, viewThemeUtils);
-            binding.shareFileIcon.setImageDrawable(drawable);
+            // NMC Customization: No overlay icon will be used. Directly using folder icons
+            binding.shareFileIcon.setImageDrawable(ContextCompat.getDrawable(this, overlayIconId));
         } else {
             binding.shareFileIcon.setImageDrawable(MimeTypeUtil.getFileTypeIcon(file.getMimeType(),
                                                                                 file.getFileName(),

--- a/app/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.kt
+++ b/app/src/main/java/com/owncloud/android/ui/adapter/ReceiveExternalFilesAdapter.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.nextcloud.client.account.User
 import com.owncloud.android.databinding.UploaderListItemLayoutBinding
@@ -113,10 +114,9 @@ class ReceiveExternalFilesAdapter(
 
     private fun setupThumbnailForFolder(thumbnailImageView: ImageView, file: OCFile) {
         val isAutoUploadFolder = SyncedFolderProvider.isAutoUploadFolder(syncedFolderProvider, file, user)
-        val isDarkModeActive = syncedFolderProvider.preferences.isDarkModeEnabled
         val overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder)
-        val icon = MimeTypeUtil.getFileIcon(isDarkModeActive, overlayIconId, context, viewThemeUtils)
-        thumbnailImageView.setImageDrawable(icon)
+        // NMC Customization: No overlay icon will be used. Directly using folder icons
+        thumbnailImageView.setImageDrawable(ContextCompat.getDrawable(context, overlayIconId))
     }
 
     @Suppress("NestedBlockDepth")

--- a/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
+++ b/app/src/main/java/com/owncloud/android/utils/DisplayUtils.java
@@ -32,7 +32,6 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.LayerDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.text.Spannable;
@@ -105,6 +104,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.widget.AppCompatDrawableManager;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
@@ -865,11 +865,9 @@ public final class DisplayUtils {
             stopShimmer(shimmerThumbnail, thumbnailView);
 
             boolean isAutoUploadFolder = SyncedFolderProvider.isAutoUploadFolder(syncedFolderProvider, file, user);
-            boolean isDarkModeActive = preferences.isDarkModeEnabled();
-
             Integer overlayIconId = file.getFileOverlayIconId(isAutoUploadFolder);
-            LayerDrawable fileIcon = MimeTypeUtil.getFileIcon(isDarkModeActive, overlayIconId, context, viewThemeUtils);
-            thumbnailView.setImageDrawable(fileIcon);
+            // NMC Customization: No overlay icon will be used. Directly using folder icons
+            thumbnailView.setImageDrawable(ContextCompat.getDrawable(context, overlayIconId));
         } else {
             if (file.getRemoteId() != null && file.isPreviewAvailable()) {
                 // Thumbnail in cache?

--- a/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
+++ b/app/src/main/java/com/owncloud/android/utils/MimeTypeUtil.java
@@ -94,13 +94,8 @@ public final class MimeTypeUtil {
                                            ViewThemeUtils viewThemeUtils) {
         if (context != null) {
             int iconId = MimeTypeUtil.getFileTypeIconId(mimetype, filename);
-            Drawable icon = ContextCompat.getDrawable(context, iconId);
-
-            if (R.drawable.file_zip == iconId) {
-                viewThemeUtils.platform.tintPrimaryDrawable(context, icon);
-            }
-
-            return icon;
+            //NMC Customization
+            return ContextCompat.getDrawable(context, iconId);
         } else {
             return null;
         }
@@ -128,11 +123,13 @@ public final class MimeTypeUtil {
         Drawable drawable = ContextCompat.getDrawable(context, R.drawable.folder);
         assert(drawable != null);
 
-        viewThemeUtils.platform.tintDrawable(context, drawable, ColorRole.PRIMARY);
         return drawable;
     }
 
-    public static LayerDrawable getFileIcon(Boolean isDarkModeActive, Integer overlayIconId, Context context, ViewThemeUtils viewThemeUtils) {
+    // NMC Note: This funtion won't be used in NMC as we are using different folder icons with inbuilt overlay. So this function is of no use for us.
+    // changed access to PRIVATE, in case if NC will use this function in more areas then we will get compile error which can be fixed by us
+    // so that UI won't be impacted.
+    private static LayerDrawable getFileIcon(Boolean isDarkModeActive, Integer overlayIconId, Context context, ViewThemeUtils viewThemeUtils) {
         Drawable folderDrawable = getDefaultFolderIcon(context, viewThemeUtils);
         assert(folderDrawable != null);
 


### PR DESCRIPTION
Tinting removed for folder & file icons.
Share icon changed.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
