### PR TITLE
Avoid multiple api calls on create button click

### DIFF
--- a/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/dialog/ChooseRichDocumentsTemplateDialogFragment.java
@@ -108,6 +108,8 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
 
     ChooseTemplateBinding binding;
 
+    private CreateFileFromTemplateTask createFileFromTemplateTask = null;
+
     @NextcloudServer(max = 18) // will be removed in favor of generic direct editing
     public static ChooseRichDocumentsTemplateDialogFragment newInstance(OCFile parentFolder, Type type) {
         ChooseRichDocumentsTemplateDialogFragment frag = new ChooseRichDocumentsTemplateDialogFragment();
@@ -231,10 +233,16 @@ public class ChooseRichDocumentsTemplateDialogFragment extends DialogFragment im
     public void onDestroyView() {
         super.onDestroyView();
         binding = null;
+        createFileFromTemplateTask = null;
     }
 
     private void createFromTemplate(Template template, String path) {
-        new CreateFileFromTemplateTask(this, client, template, path, currentAccount.getUser()).execute();
+        if (createFileFromTemplateTask != null && createFileFromTemplateTask.getStatus() != AsyncTask.Status.FINISHED) {
+            Log_OC.d(TAG, "CreateFileFromTemplateTask already running skipping another click event");
+            return;
+        }
+        createFileFromTemplateTask = new CreateFileFromTemplateTask(this, client, template, path, currentAccount.getUser());
+        createFileFromTemplateTask.execute();
     }
 
     public void setTemplateList(List<Template> templateList) {


### PR DESCRIPTION
This PR fix both the issues by avoiding multiple API calls:

1. IllegalStateException crash
2. Avoid creating multiple office files.

Upstreamed PR link: https://github.com/nextcloud/android/pull/11815

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
