### PR TITLE
Persist last selected media folder for media view

### DIFF
--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferences.java
@@ -2,7 +2,9 @@
  * Nextcloud Android client application
  *
  * @author Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2019 Chris Narkiewicz, EZ Aquarii
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -384,4 +386,9 @@ public interface AppPreferences {
 
     @Nullable
     AppReviewShownModel getInAppReviewData();
+
+    void setLastSelectedMediaFolder(@NonNull String path);
+
+    @NonNull
+    String getLastSelectedMediaFolder();
 }

--- a/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
+++ b/app/src/main/java/com/nextcloud/client/preferences/AppPreferencesImpl.java
@@ -3,8 +3,10 @@
  *
  * @author David A. Velasco
  * @author Chris Narkiewicz Chris Narkiewicz
+ * @author TSI-mc
  * Copyright (C) 2016 ownCloud Inc.
  * Copyright (C) 2019 Chris Narkiewicz <hello@ezaquarii.com>
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -99,6 +101,7 @@ public final class AppPreferencesImpl implements AppPreferences {
     private static final String PREF__CALENDAR_LAST_BACKUP = "calendar_last_backup";
 
     private static final String PREF__PDF_ZOOM_TIP_SHOWN = "pdf_zoom_tip_shown";
+    private static final String PREF__MEDIA_FOLDER_LAST_PATH = "media_folder_last_path";
 
     private static final String PREF__STORAGE_PERMISSION_REQUESTED = "storage_permission_requested";
     private static final String PREF__IN_APP_REVIEW_DATA = "in_app_review_data";
@@ -728,5 +731,16 @@ public final class AppPreferencesImpl implements AppPreferences {
         Gson gson = new Gson();
         String json = preferences.getString(PREF__IN_APP_REVIEW_DATA, "");
         return gson.fromJson(json, AppReviewShownModel.class);
+    }
+
+    @Override
+    public void setLastSelectedMediaFolder(@NonNull String path) {
+        preferences.edit().putString(PREF__MEDIA_FOLDER_LAST_PATH, path).apply();
+    }
+
+    @NonNull
+    @Override
+    public String getLastSelectedMediaFolder() {
+        return preferences.getString(PREF__MEDIA_FOLDER_LAST_PATH, OCFile.ROOT_PATH);
     }
 }

--- a/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
+++ b/app/src/main/java/com/owncloud/android/ui/fragment/GalleryFragment.java
@@ -5,7 +5,7 @@
  * @author TSI-mc
  * Copyright (C) 2019 Tobias Kaminsky
  * Copyright (C) 2019 Nextcloud GmbH
- * Copyright (C) 2022 TSI-mc
+ * Copyright (C) 2023 TSI-mc
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -70,7 +70,6 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
     private GalleryAdapter mAdapter;
 
     private static final int SELECT_LOCATION_REQUEST_CODE = 212;
-    private OCFile remoteFile;
     private GalleryFragmentBottomSheetDialog galleryFragmentBottomSheetDialog;
 
     @Inject FileDataStorageManager fileDataStorageManager;
@@ -120,8 +119,6 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View v = super.onCreateView(inflater, container, savedInstanceState);
-
-        remoteFile = fileDataStorageManager.getDefaultRootPath();
 
         getRecyclerView().addOnScrollListener(new RecyclerView.OnScrollListener() {
             @Override
@@ -289,7 +286,7 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
         if (requestCode == SELECT_LOCATION_REQUEST_CODE && data != null) {
             OCFile chosenFolder = data.getParcelableExtra(FolderPickerActivity.EXTRA_FOLDER);
             if (chosenFolder != null) {
-                remoteFile = chosenFolder;
+                preferences.setLastSelectedMediaFolder(chosenFolder.getRemotePath());
                 searchAndDisplayAfterChangingFolder();
             }
         }
@@ -372,7 +369,7 @@ public class GalleryFragment extends OCFileListFragment implements GalleryFragme
     }
 
     public void showAllGalleryItems() {
-        mAdapter.showAllGalleryItems(remoteFile.getRemotePath(),
+        mAdapter.showAllGalleryItems(preferences.getLastSelectedMediaFolder(),
                                      galleryFragmentBottomSheetDialog.getCurrMediaState(),
                                      this);
 


### PR DESCRIPTION
This PR contains the functionality to persist the last selected media folder for the Media View tab.

Upstream PR: https://github.com/nextcloud/android/pull/11819

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
