### PR TITLE
[backport 7.21] Fix local db version to avoid crash during app upgrade

### DIFF
--- a/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
+++ b/app/src/main/java/com/nextcloud/client/database/NextcloudDatabase.kt
@@ -74,7 +74,10 @@ abstract class NextcloudDatabase : RoomDatabase() {
     abstract fun fileDao(): FileDao
 
     companion object {
-        const val FIRST_ROOM_DB_VERSION = 65
+        //NMC customization
+        //NMC play store version 7.21.9 had db version 64 before SqLite to Room migration
+        //Keeping it 65(as per NC) will lead to crash when user tried to upgrade the app
+        const val FIRST_ROOM_DB_VERSION = 64
         private var INSTANCE: NextcloudDatabase? = null
 
         @JvmStatic

--- a/app/src/test/java/com/nmc/DatabaseVersionTest.kt
+++ b/app/src/test/java/com/nmc/DatabaseVersionTest.kt
@@ -1,0 +1,14 @@
+package com.nmc
+
+import com.nextcloud.client.database.NextcloudDatabase
+import org.junit.Test
+
+class DatabaseVersionTest {
+
+    @Test
+    fun validateDatabaseVersion() {
+        //for NMC the version will start from 64 only
+        //validating via test case to check if any test changes done during rebasing or merging
+        assert(64 == NextcloudDatabase.FIRST_ROOM_DB_VERSION)
+    }
+}


### PR DESCRIPTION
App is crashing or stuck at launcher screen when user upgrade to latest app.
But for fresh install there won't be any crash.

Example: If user has play store version 7.21.9 and user upgrade to 7.21.18. The app will crash for that user.

<!--
TESTING

Writing tests is very important. Please try to write some tests for your PR. 
If you need help, please do not hesitate to ask in this PR for help.

Unit tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#unit-tests
Instrumented tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#instrumented-tests
UI tests: https://github.com/nextcloud/android/blob/master/CONTRIBUTING.md#ui-tests
 -->
- [ ] Tests written, or not not needed
